### PR TITLE
Bugfix: resetting blockchain state only on error

### DIFF
--- a/ledger/src/signer/src/bc_advance.c
+++ b/ledger/src/signer/src/bc_advance.c
@@ -666,8 +666,6 @@ static const rlp_callbacks_t callbacks = {
  * Initialize Blockchain advance protocol state.
  */
 void bc_init_advance() {
-    RESET_BC_STATE();
-
     expected_blocks = 0;
     curr_block = 0;
     expected_state = OP_ADVANCE_INIT;

--- a/ledger/src/signer/src/hsm.c
+++ b/ledger/src/signer/src/hsm.c
@@ -209,6 +209,7 @@ unsigned int hsm_process_exception(unsigned short code, unsigned int tx) {
 
     // Always reset the full state when an error occurs
     if (code != 0x9000) {
+        RESET_BC_STATE();
         reset_if_starting(0);
     }
 


### PR DESCRIPTION
The `updating` subsection of the blockchain state was being reset on every change of operation, which meant that trying to read the current blockchain state would imply a prior reset of that subsection, which is not the intended behavior. This was accidentally introduced as part of a refactor in [this PR](https://github.com/rsksmart/rsk-powhsm/pull/3).

Fixed by means of resetting only upon error.