### PR TITLE
Offset parameters in SAFE_MEMMOVE

### DIFF
--- a/ledger/src/common/src/memutil.h
+++ b/ledger/src/common/src/memutil.h
@@ -24,11 +24,25 @@
 
 #include "os.h"
 
-#define SAFE_MEMMOVE(dest, dest_size, src, src_size, n, ERR_EXPR) \
-    {                                                             \
-        if ((n) < 0 || (n) > (dest_size) || (n) > (src_size)) {   \
-            ERR_EXPR;                                             \
-        } else {                                                  \
-            os_memmove(dest, src, n);                             \
-        }                                                         \
+#define SAFE_MEMMOVE(                                                       \
+    dst, dst_size, dst_off, src, src_size, src_off, n, ERR_EXPR)            \
+    {                                                                       \
+        if (((unsigned int)(n)) > ((unsigned int)(dst_size)) ||             \
+            ((unsigned int)(n)) > ((unsigned int)(src_size)) ||             \
+            ((unsigned int)(dst_off)) > ((unsigned int)(dst_size)) ||       \
+            ((unsigned int)(src_off)) > ((unsigned int)(src_size)) ||       \
+            ((unsigned int)(n) + (unsigned int)(dst_off)) <                 \
+                ((unsigned int)(n)) ||                                      \
+            ((unsigned int)(n) + (unsigned int)(src_off)) <                 \
+                ((unsigned int)(n)) ||                                      \
+            ((unsigned int)(n) + (unsigned int)(dst_off)) >                 \
+                ((unsigned int)(dst_size)) ||                               \
+            ((unsigned int)(n) + (unsigned int)(src_off)) >                 \
+                ((unsigned int)(src_size))) {                               \
+            ERR_EXPR;                                                       \
+        } else {                                                            \
+            os_memmove(((unsigned char*)(dst)) + ((unsigned int)(dst_off)), \
+                       ((unsigned char*)(src)) + ((unsigned int)(src_off)), \
+                       (unsigned int)(n));                                  \
+        }                                                                   \
     }

--- a/ledger/src/common/test/memutil/test_memutil.c
+++ b/ledger/src/common/test/memutil/test_memutil.c
@@ -25,10 +25,36 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <assert.h>
+#include <limits.h>
 
 #include "memutil.h"
 
-void os_memmove(void *dst, const void *src, unsigned int length) {
+#define TEST_MEMMOVE(                                                      \
+    dst, dst_size, dst_off, src, src_size, src_off, n, ERR_EXPR)           \
+    {                                                                      \
+        expected_dst =                                                     \
+            (unsigned char*)((unsigned char*)dst + (unsigned int)dst_off); \
+        expected_src =                                                     \
+            (unsigned char*)((unsigned char*)src + (unsigned int)src_off); \
+        expected_length = (unsigned int)n;                                 \
+        SAFE_MEMMOVE(                                                      \
+            dst, dst_size, dst_off, src, src_size, src_off, n, ERR_EXPR);  \
+    }
+
+unsigned char* expected_dst;
+unsigned char* expected_src;
+unsigned int expected_length;
+int copied;
+
+void os_memmove_reset_mock() {
+    copied = 0;
+}
+
+void os_memmove(void* dst, const void* src, unsigned int length) {
+    assert(expected_dst == dst);
+    assert(expected_src == src);
+    assert(expected_length == length);
+    copied++;
 }
 
 void test_ok() {
@@ -36,45 +62,113 @@ void test_ok() {
     char src[15];
     char dst[10];
 
-    SAFE_MEMMOVE(src, sizeof(src), dst, sizeof(dst), 10, { assert(false); });
-    SAFE_MEMMOVE(src, sizeof(src), dst, sizeof(dst), 9, { assert(false); });
-    SAFE_MEMMOVE(src, sizeof(src), dst, sizeof(dst), 4, { assert(false); });
+    os_memmove_reset_mock();
+    TEST_MEMMOVE(
+        dst, sizeof(dst), 0, src, sizeof(src), 0, 10, { assert(false); });
+    TEST_MEMMOVE(
+        dst, sizeof(dst), 0, src, sizeof(src), 0, 9, { assert(false); });
+    TEST_MEMMOVE(
+        dst, sizeof(dst), 0, src, sizeof(src), 0, 4, { assert(false); });
+    TEST_MEMMOVE(
+        dst, sizeof(dst), 1, src, sizeof(src), 2, 4, { assert(false); });
+    TEST_MEMMOVE(
+        dst, sizeof(dst), 4, src, sizeof(src), 9, 6, { assert(false); });
+    assert(copied == 5);
 }
 
-void test_negative() {
-    printf("Test negative length...\n");
+void test_negatives() {
+    printf("Test negatives...\n");
     char src[15];
     char dst[10];
+    int failed = 0;
 
-    SAFE_MEMMOVE(src, sizeof(src), dst, sizeof(dst), -1, { return; });
-    SAFE_MEMMOVE(src, sizeof(src), dst, sizeof(dst), -5, { return; });
-    assert(false);
+    os_memmove_reset_mock();
+    TEST_MEMMOVE(dst, sizeof(dst), 0, src, sizeof(src), 0, -1, { failed++; });
+    TEST_MEMMOVE(dst, sizeof(dst), 0, src, sizeof(src), 0, -5, { failed++; });
+    TEST_MEMMOVE(dst, sizeof(dst), -1, src, sizeof(src), 0, 2, { failed++; });
+    TEST_MEMMOVE(dst, sizeof(dst), 0, src, sizeof(src), -1, 8, { failed++; });
+    assert(failed == 4);
+    assert(!copied);
 }
 
 void test_src_outofbounds() {
     printf("Test read src out of bounds...\n");
     char src[5];
     char dst[10];
+    int failed = 0;
 
-    SAFE_MEMMOVE(src, sizeof(src), dst, sizeof(dst), 6, { return; });
-    SAFE_MEMMOVE(src, sizeof(src), dst, sizeof(dst), 7, { return; });
-    assert(false);
+    os_memmove_reset_mock();
+    TEST_MEMMOVE(dst, sizeof(dst), 0, src, sizeof(src), 0, 6, { failed++; });
+    TEST_MEMMOVE(dst, sizeof(dst), 0, src, sizeof(src), 0, 7, { failed++; });
+    assert(failed == 2);
+    assert(!copied);
+}
+
+void test_src_outofbounds_offset() {
+    printf("Test read src out of bounds with offset...\n");
+    char src[15];
+    char dst[10];
+    int failed = 0;
+
+    os_memmove_reset_mock();
+    TEST_MEMMOVE(dst, sizeof(dst), 0, src, sizeof(src), 6, 10, { failed++; });
+    TEST_MEMMOVE(dst, sizeof(dst), 0, src, sizeof(src), 15, 4, { failed++; });
+    assert(failed == 2);
+    assert(!copied);
 }
 
 void test_dst_outofbounds() {
     printf("Test read dst out of bounds...\n");
     char src[15];
     char dst[10];
+    int failed = 0;
 
-    SAFE_MEMMOVE(src, sizeof(src), dst, sizeof(dst), 11, { return; });
-    SAFE_MEMMOVE(src, sizeof(src), dst, sizeof(dst), 13, { return; });
-    assert(false);
+    os_memmove_reset_mock();
+    TEST_MEMMOVE(dst, sizeof(dst), 0, src, sizeof(src), 0, 11, { failed++; });
+    TEST_MEMMOVE(dst, sizeof(dst), 0, src, sizeof(src), 0, 13, { failed++; });
+    assert(failed == 2);
+    assert(!copied);
+}
+
+void test_dst_outofbounds_offset() {
+    printf("Test read dst out of bounds with offset...\n");
+    char src[5];
+    char dst[10];
+    int failed = 0;
+
+    os_memmove_reset_mock();
+    TEST_MEMMOVE(dst, sizeof(dst), 8, src, sizeof(src), 0, 3, { failed++; });
+    TEST_MEMMOVE(dst, sizeof(dst), 10, src, sizeof(src), 0, 1, { failed++; });
+    assert(failed == 2);
+    assert(!copied);
+}
+
+void test_overflow() {
+    printf("Test overflow...\n");
+    char src[5];
+    char dst[10];
+    int failed = 0;
+
+    os_memmove_reset_mock();
+    TEST_MEMMOVE(
+        dst, sizeof(dst), 10, src, sizeof(src), 0, UINT_MAX - 5, { failed++; });
+    TEST_MEMMOVE(
+        dst, sizeof(dst), UINT_MAX, src, sizeof(src), 0, 5, { failed++; });
+    TEST_MEMMOVE(
+        dst, sizeof(dst), 0, src, sizeof(src), 10, UINT_MAX - 5, { failed++; });
+    TEST_MEMMOVE(
+        dst, sizeof(dst), 0, src, sizeof(src), UINT_MAX, 5, { failed++; });
+    assert(failed == 4);
+    assert(!copied);
 }
 
 int main() {
     test_ok();
-    test_negative();
+    test_negatives();
     test_src_outofbounds();
+    test_src_outofbounds_offset();
     test_dst_outofbounds();
+    test_dst_outofbounds_offset();
+    test_overflow();
     return 0;
 }

--- a/ledger/src/signer/src/attestation.c
+++ b/ledger/src/signer/src/attestation.c
@@ -48,8 +48,10 @@ static void hash_public_key(const char* path,
             // Skip first byte of path when copying (path size byte)
             SAFE_MEMMOVE(att_ctx->path,
                          sizeof(att_ctx->path),
-                         (unsigned int*)(path + 1),
-                         path_size - 1,
+                         0,
+                         (unsigned int*)path,
+                         path_size,
+                         1,
                          sizeof(att_ctx->path),
                          THROW(ATT_INTERNAL));
 
@@ -106,8 +108,10 @@ static unsigned int generate_message_to_sign(att_t* att_ctx) {
     // Copy the message prefix
     SAFE_MEMMOVE(att_ctx->msg,
                  sizeof(att_ctx->msg),
+                 0,
                  PIC(ATT_MSG_PREFIX),
                  ATT_MSG_PREFIX_LENGTH,
+                 0,
                  ATT_MSG_PREFIX_LENGTH,
                  THROW(ATT_INTERNAL));
 
@@ -150,8 +154,10 @@ unsigned int get_attestation(volatile unsigned int rx, att_t* att_ctx) {
 
         SAFE_MEMMOVE(APDU_DATA_PTR,
                      APDU_TOTAL_DATA_SIZE,
+                     0,
                      att_ctx->msg,
                      sizeof(att_ctx->msg),
+                     0,
                      message_size,
                      THROW(ATT_INTERNAL));
 

--- a/ledger/src/signer/src/bc_advance.c
+++ b/ledger/src/signer/src/bc_advance.c
@@ -90,10 +90,12 @@ static uint8_t expected_state;
  * @arg[in] size buffer size in bytes
  */
 static void wa_store(const uint8_t* buf, uint16_t size) {
-    SAFE_MEMMOVE(block.wa_buf + block.wa_off,
-                 sizeof(block.wa_buf) - block.wa_off,
+    SAFE_MEMMOVE(block.wa_buf,
+                 sizeof(block.wa_buf),
+                 block.wa_off,
                  buf,
                  size,
+                 0,
                  size,
                  FAIL(BUFFER_OVERFLOW));
 
@@ -141,10 +143,12 @@ static void process_merkle_proof(const uint8_t* chunk, uint16_t size) {
  * @arg[in] size  chunk size in bytes
  */
 static void store_cb_txn_bytes(const uint8_t* chunk, uint16_t size) {
-    SAFE_MEMMOVE(block.cb_txn + block.cb_off,
-                 sizeof(block.cb_txn) - block.cb_off,
+    SAFE_MEMMOVE(block.cb_txn,
+                 sizeof(block.cb_txn),
+                 block.cb_off,
                  chunk,
                  size,
+                 0,
                  size,
                  FAIL(CB_TXN_OVERFLOW));
 
@@ -513,8 +517,10 @@ static void str_start(const uint16_t size) {
         // reduction area
         SAFE_MEMMOVE(block.merkle_proof_left,
                      sizeof(block.merkle_proof_left),
+                     0,
                      block.cb_txn_hash,
                      sizeof(block.cb_txn_hash),
+                     0,
                      sizeof(block.cb_txn_hash),
                      FAIL(MERKLE_PROOF_INVALID));
     }
@@ -624,8 +630,10 @@ static void str_end() {
 
             SAFE_MEMMOVE(block.umm_root,
                          sizeof(block.umm_root),
+                         0,
                          block.wa_buf,
                          sizeof(block.wa_buf),
+                         0,
                          block.wa_off,
                          FAIL(UMM_ROOT_INVALID));
         }
@@ -736,8 +744,10 @@ unsigned int bc_advance(volatile unsigned int rx) {
         memset(aux_bc_st.prev_parent_hash, 0, HASH_SIZE);
         SAFE_MEMMOVE(aux_bc_st.total_difficulty,
                      sizeof(aux_bc_st.total_difficulty),
+                     0,
                      N_bc_state.updating.total_difficulty,
                      sizeof(N_bc_state.updating.total_difficulty),
+                     0,
                      sizeof(aux_bc_st.total_difficulty),
                      FAIL(PROT_INVALID));
 
@@ -770,8 +780,10 @@ unsigned int bc_advance(volatile unsigned int rx) {
         // Read the coinbase transaction hash
         SAFE_MEMMOVE(block.cb_txn_hash,
                      sizeof(block.cb_txn_hash),
-                     APDU_DATA_PTR + sizeof(block.mm_rlp_len),
-                     APDU_TOTAL_DATA_SIZE - sizeof(block.mm_rlp_len),
+                     0,
+                     APDU_DATA_PTR,
+                     APDU_TOTAL_DATA_SIZE,
+                     sizeof(block.mm_rlp_len),
                      sizeof(block.cb_txn_hash),
                      FAIL(PROT_INVALID));
 

--- a/ledger/src/signer/src/bc_ancestor.c
+++ b/ledger/src/signer/src/bc_ancestor.c
@@ -63,10 +63,12 @@ static uint8_t expected_state;
  * @arg[in] size buffer size in bytes
  */
 static void wa_store(const uint8_t* buf, uint16_t size) {
-    SAFE_MEMMOVE(block.wa_buf + block.wa_off,
-                 sizeof(block.wa_buf) - block.wa_off,
+    SAFE_MEMMOVE(block.wa_buf,
+                 sizeof(block.wa_buf),
+                 block.wa_off,
                  buf,
                  size,
+                 0,
                  size,
                  FAIL(BUFFER_OVERFLOW));
 

--- a/ledger/src/signer/src/bc_state.c
+++ b/ledger/src/signer/src/bc_state.c
@@ -122,10 +122,12 @@ uint8_t dump_hash(uint8_t hash_code) {
     }
 
     APDU_DATA_PTR[0] = hash_code;
-    SAFE_MEMMOVE(APDU_DATA_PTR + 1,
-                 APDU_TOTAL_DATA_SIZE - 1,
+    SAFE_MEMMOVE(APDU_DATA_PTR,
+                 APDU_TOTAL_DATA_SIZE,
+                 1,
                  h,
                  HASH_SIZE,
+                 0,
                  HASH_SIZE,
                  FAIL(PROT_INVALID));
 
@@ -147,8 +149,10 @@ uint8_t dump_difficulty() {
         continue;
     SAFE_MEMMOVE(APDU_DATA_PTR,
                  APDU_TOTAL_DATA_SIZE,
-                 buf + start,
-                 sizeof(buf) - start,
+                 0,
+                 buf,
+                 sizeof(buf),
+                 start,
                  sizeof(buf) - start,
                  FAIL(PROT_INVALID));
     return sizeof(buf) - start;
@@ -161,10 +165,12 @@ uint8_t dump_difficulty() {
  * @ret number of bytes dumped to APDU buffer
  */
 uint8_t bc_dump_initial_block_hash(int offset) {
-    SAFE_MEMMOVE(APDU_DATA_PTR + offset,
-                 APDU_TOTAL_DATA_SIZE - offset,
+    SAFE_MEMMOVE(APDU_DATA_PTR,
+                 APDU_TOTAL_DATA_SIZE,
+                 offset,
                  INITIAL_BLOCK_HASH,
                  sizeof(INITIAL_BLOCK_HASH),
+                 0,
                  sizeof(INITIAL_BLOCK_HASH),
                  FAIL(PROT_INVALID));
     return sizeof(INITIAL_BLOCK_HASH);

--- a/ledger/src/signer/src/hsm.c
+++ b/ledger/src/signer/src/hsm.c
@@ -166,8 +166,10 @@ unsigned int hsm_process_apdu(volatile unsigned int rx) {
         // Derive the public key
         SAFE_MEMMOVE(path,
                      sizeof(path),
+                     0,
                      APDU_DATA_PTR,
                      APDU_TOTAL_DATA_SIZE,
+                     0,
                      RSK_PATH_LEN * sizeof(uint32_t),
                      THROW(0x6A8F));
         tx = do_pubkey(

--- a/ledger/src/signer/src/ins_sign.h
+++ b/ledger/src/signer/src/ins_sign.h
@@ -55,8 +55,10 @@ while (true) {
                            // (DATA+PATHLEN+HASHEN)
         SAFE_MEMMOVE(path,
                      sizeof(path),
-                     APDU_DATA_PTR + 1,
-                     APDU_TOTAL_DATA_SIZE - 1,
+                     0,
+                     APDU_DATA_PTR,
+                     APDU_TOTAL_DATA_SIZE,
+                     1,
                      RSK_PATH_LEN * sizeof(int),
                      THROW(0x6A87));
         // If path requires authorization, continue with authorization and
@@ -66,8 +68,10 @@ while (true) {
                 THROW(0x6A90); // Wrong buffer size for authorized sign
             SAFE_MEMMOVE(&tx_ctx.tx_input_index_to_sign,
                          sizeof(tx_ctx.tx_input_index_to_sign),
-                         APDU_DATA_PTR + PATHLEN,
-                         APDU_TOTAL_DATA_SIZE - PATHLEN,
+                         0,
+                         APDU_DATA_PTR,
+                         APDU_TOTAL_DATA_SIZE,
+                         PATHLEN,
                          INPUTINDEXLEN,
                          THROW(0x6A87));
             SET_APDU_OP(P1_BTC);
@@ -91,8 +95,10 @@ while (true) {
             // Skip validations
             SAFE_MEMMOVE(mp_ctx.signatureHash,
                          sizeof(mp_ctx.signatureHash),
-                         APDU_DATA_PTR + PATHLEN,
-                         APDU_TOTAL_DATA_SIZE - PATHLEN,
+                         0,
+                         APDU_DATA_PTR,
+                         APDU_TOTAL_DATA_SIZE,
+                         PATHLEN,
                          sizeof(mp_ctx.signatureHash),
                          THROW(0x6A87));
             tx = TX_FOR_TXLEN();
@@ -106,8 +112,10 @@ while (true) {
     // blockchain state
     SAFE_MEMMOVE(ReceiptsRootBuf,
                  sizeof(ReceiptsRootBuf),
+                 0,
                  N_bc_state.ancestor_receipt_root,
                  sizeof(N_bc_state.ancestor_receipt_root),
+                 0,
                  sizeof(ReceiptsRootBuf),
                  THROW(0x6A87));
 
@@ -300,8 +308,10 @@ while (true) {
         case S_MP_START:
             SAFE_MEMMOVE(signatureHashCopy,
                          sizeof(signatureHashCopy),
+                         0,
                          tx_ctx.signatureHashBuf,
                          sizeof(tx_ctx.signatureHashBuf),
+                         0,
                          sizeof(signatureHashCopy),
                          THROW(0x6A87));
             MP_START(&mp_ctx,

--- a/ledger/src/signer/src/merkleProof.c
+++ b/ledger/src/signer/src/merkleProof.c
@@ -65,20 +65,26 @@ void MP_START(MP_CTX *ctx,
     // Copy parameters (ReceiptHash and ReceiptsRoot)
     SAFE_MEMMOVE(ctx->receiptHash,
                  sizeof(ctx->receiptHash),
+                 0,
                  Receipt_Hash,
                  HASHLEN,
+                 0,
                  HASHLEN,
                  THROW(0x6A87));
     SAFE_MEMMOVE(ctx->receiptsRoot,
                  sizeof(ctx->receiptsRoot),
+                 0,
                  receiptsRoot,
                  HASHLEN,
+                 0,
                  HASHLEN,
                  THROW(0x6A87));
     SAFE_MEMMOVE(ctx->signatureHash,
                  sizeof(ctx->signatureHash),
+                 0,
                  signatureHash,
                  HASHLEN,
+                 0,
                  HASHLEN,
                  THROW(0x6A87));
     LOG("MP START rx:%d\n", rx);
@@ -234,8 +240,10 @@ void MP_NODE_SHARED_PREFIX_VARINT_BODY(MP_CTX *ctx,
     // Read length from input
     SAFE_MEMMOVE(&length,
                  sizeof(length),
+                 0,
                  APDU_DATA_PTR,
                  APDU_TOTAL_DATA_SIZE,
+                 0,
                  APDU_DATA_SIZE(rx),
                  THROW(0x6A87));
     // Shared prefixes over MAX_MP_TRANSFER_SIZE not supported
@@ -289,8 +297,10 @@ void MP_NODE_LEFT(MP_CTX *ctx,
         // Copy hash and continue parsing
         SAFE_MEMMOVE(ctx->left_node_hash,
                      sizeof(ctx->left_node_hash),
+                     0,
                      APDU_DATA_PTR,
                      APDU_TOTAL_DATA_SIZE,
+                     0,
                      HASHLEN,
                      THROW(0x6A87));
         SET_APDU_TXLEN(0);
@@ -361,8 +371,10 @@ void MP_NODE_RIGHT(MP_CTX *ctx,
         // Copy hash and continue parsing
         SAFE_MEMMOVE(ctx->right_node_hash,
                      sizeof(ctx->right_node_hash),
+                     0,
                      APDU_DATA_PTR,
                      APDU_TOTAL_DATA_SIZE,
+                     0,
                      HASHLEN,
                      THROW(0x6A87));
         SET_APDU_TXLEN(0);
@@ -483,8 +495,10 @@ void MP_NODE_VALUE_LEN(MP_CTX *ctx,
     // ValueHash
     SAFE_MEMMOVE(ctx->value_hash,
                  sizeof(ctx->value_hash),
+                 0,
                  APDU_DATA_PTR,
                  APDU_TOTAL_DATA_SIZE,
+                 0,
                  HASHLEN,
                  THROW(0x6A87));
     // Check Receipt hash, must be equal that the first trie node value

--- a/ledger/src/signer/src/rlp.c
+++ b/ledger/src/signer/src/rlp.c
@@ -186,10 +186,12 @@ void SM_RLP_HDR(RLP_CTX *ctx,
         LOG("RLP decode buffer would overflow\n");
         THROW(0x6A8A);
     }
-    SAFE_MEMMOVE(ctx->decodeBuffer + ctx->decodeOffset,
-                 sizeof(ctx->decodeBuffer) - ctx->decodeOffset,
+    SAFE_MEMMOVE(ctx->decodeBuffer,
+                 sizeof(ctx->decodeBuffer),
+                 ctx->decodeOffset,
                  APDU_DATA_PTR,
                  APDU_TOTAL_DATA_SIZE,
+                 0,
                  1,
                  THROW(0x6A8A));
     ctx->decodeOffset++;

--- a/ledger/src/signer/src/sign.c
+++ b/ledger/src/signer/src/sign.c
@@ -68,8 +68,10 @@ int do_pubkey(unsigned int* path,
             pubkey_size = public_key.W_len;
             SAFE_MEMMOVE(dest,
                          dest_size,
+                         0,
                          public_key.W,
                          public_key.W_len,
+                         0,
                          public_key.W_len,
                          { pubkey_size = DO_PUBKEY_ERROR; })
             // Cleanup public key

--- a/ledger/src/signer/src/txparser.c
+++ b/ledger/src/signer/src/txparser.c
@@ -68,14 +68,18 @@ void SM_TX_HDR(TX_CTX *ctx,
     ctx->tx_total_read += rx - (DATA + 4);
     SAFE_MEMMOVE(&ctx->tx_total_len,
                  sizeof(ctx->tx_total_len),
+                 0,
                  APDU_DATA_PTR,
                  APDU_TOTAL_DATA_SIZE,
+                 0,
                  4,
                  THROW(0x6A87));
     SAFE_MEMMOVE(&ctx->tx_version,
                  sizeof(ctx->tx_version),
-                 APDU_DATA_PTR + 4,
-                 APDU_TOTAL_DATA_SIZE - 4,
+                 0,
+                 APDU_DATA_PTR,
+                 APDU_TOTAL_DATA_SIZE,
+                 4,
                  4,
                  THROW(0x6A87));
     LOG(" TX_HDR: TX total len %u\n", ctx->tx_total_len);
@@ -151,8 +155,10 @@ void SM_TX_VARINT(TX_CTX *ctx,
         ctx->script_length = 0;
         SAFE_MEMMOVE(&ctx->script_length,
                      sizeof(ctx->script_length),
+                     0,
                      APDU_DATA_PTR,
                      APDU_TOTAL_DATA_SIZE,
+                     0,
                      APDU_DATA_SIZE(rx),
                      THROW(0x6A87));
     }

--- a/ledger/src/ui/src/bolos_ux.c
+++ b/ledger/src/ui/src/bolos_ux.c
@@ -720,8 +720,10 @@ int is_app_version_allowed(application_t *app) {
     currentHash = (unsigned char *)PIC(N_SignerHashList[0]);
     SAFE_MEMMOVE(cmpbuf,
                  sizeof(cmpbuf),
+                 0,
                  currentHash,
                  sizeof(N_SignerHashList[0]),
+                 0,
                  COMPRESSEDHASHSIZE,
                  { return 0; });
     // Compare the first COMPRESSEDHASHSIZE bytes
@@ -732,8 +734,10 @@ int is_app_version_allowed(application_t *app) {
         currentHash = (unsigned char *)PIC(N_SignerHashList[i]);
         SAFE_MEMMOVE(cmpbuf,
                      sizeof(cmpbuf),
+                     0,
                      currentHash,
                      sizeof(N_SignerHashList[i]),
+                     0,
                      COMPRESSEDHASHSIZE,
                      { return 0; })
         // Compare the first COMPRESSEDHASHSIZE bytes
@@ -747,8 +751,10 @@ int is_app_version_allowed(application_t *app) {
         oldHash = (unsigned char *)PIC(N_SignerHashList[i - 1]);
         SAFE_MEMMOVE(cmpbuf,
                      sizeof(cmpbuf),
+                     0,
                      oldHash,
                      sizeof(N_SignerHashList[i - 1]),
+                     0,
                      COMPRESSEDHASHSIZE,
                      { return 0; });
         nvm_write(currentHash, cmpbuf, COMPRESSEDHASHSIZE);
@@ -756,7 +762,7 @@ int is_app_version_allowed(application_t *app) {
     // Write new hash in current app hash
     currentHash = (unsigned char *)PIC(N_SignerHashList[0]);
     SAFE_MEMMOVE(
-        cmpbuf, sizeof(cmpbuf), app->hash, sizeof(app->hash), HASHSIZE, {
+        cmpbuf, sizeof(cmpbuf), 0, app->hash, sizeof(app->hash), 0, HASHSIZE, {
             return 0;
         });
     nvm_write((void *)currentHash, cmpbuf, COMPRESSEDHASHSIZE);

--- a/middleware/admin/verify_attestation.py
+++ b/middleware/admin/verify_attestation.py
@@ -110,7 +110,6 @@ def do_verify_attestation(options):
         raise AdminError("Certificate does not contain a UI attestation")
 
     ui_result = result["ui"]
-    print(ui_result)
     if not ui_result[0]:
         raise AdminError(f"Invalid UI attestation: error validating '{ui_result[1]}'")
 


### PR DESCRIPTION
- Added source and destination offsets as separate parameters to `SAFE_MEMMOVE`  
- Updated SAFE_MEMMOVE usages
- Updated `SAFE_MEMMOVE` unit tests
- Incidentally removing a 'print' call within the attestation verification script
