### PR TITLE
2.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,3 +107,9 @@ All notable changes to this project will be documented in this file.
 ### Fixes
 
 - Implemented dependabot recommended dependency bumps
+
+## [2.3.1] - 12/11/2021
+
+### Features/enhancements
+
+- Added source and destination offsets as additional parameters to SAFE_MEMMOVE

--- a/ledger/src/signer/src/defs.h
+++ b/ledger/src/signer/src/defs.h
@@ -30,7 +30,7 @@
 // Version and patchlevel
 #define VERSION_MAJOR 0x02
 #define VERSION_MINOR 0x03
-#define VERSION_PATCH 0x00
+#define VERSION_PATCH 0x01
 
 // Instructions
 #define INS_SIGN 0x02

--- a/ledger/src/ui/src/defs.h
+++ b/ledger/src/ui/src/defs.h
@@ -30,7 +30,7 @@
 // Version and patchlevel
 #define VERSION_MAJOR 0x02
 #define VERSION_MINOR 0x03
-#define VERSION_PATCH 0x00
+#define VERSION_PATCH 0x01
 
 // Instructions
 #define RSK_PIN_CMD 0x41

--- a/middleware/ledger/protocol.py
+++ b/middleware/ledger/protocol.py
@@ -36,8 +36,8 @@ from comm.bitcoin import get_unsigned_tx, get_tx_hash
 
 class HSM2ProtocolLedger(HSM2Protocol):
     # Current manager supported versions for HSM UI and HSM SIGNER (<=)
-    UI_VERSION = HSM2FirmwareVersion(2, 3, 0)
-    APP_VERSION = HSM2FirmwareVersion(2, 3, 0)
+    UI_VERSION = HSM2FirmwareVersion(2, 3, 1)
+    APP_VERSION = HSM2FirmwareVersion(2, 3, 1)
 
     # Amount of time to wait to make sure the app is opened
     OPEN_APP_WAIT = 1  # second


### PR DESCRIPTION
- Bumping UI, Signer and Manager versions to `2.3.1`
- Updating CHANGELOG