### PR TITLE
Attestation malleability fix

### DIFF
--- a/middleware/admin/attestation.py
+++ b/middleware/admin/attestation.py
@@ -130,8 +130,6 @@ def do_attestation(options):
         HSMCertificateElement({
             "name": "ui",
             "message": ui_attestation["message"],
-            "extract": ":",
-            "digest": HSMCertificateElement.DIGEST.NONE,
             "signature": ui_attestation["signature"],
             "signed_by": "attestation",
             "tweak": ui_attestation["app_hash"],
@@ -140,8 +138,6 @@ def do_attestation(options):
         HSMCertificateElement({
             "name": "signer",
             "message": signer_attestation["message"],
-            "extract": ":",
-            "digest": HSMCertificateElement.DIGEST.NONE,
             "signature": signer_attestation["signature"],
             "signed_by": "attestation",
             "tweak": signer_attestation["app_hash"],

--- a/middleware/admin/onboard.py
+++ b/middleware/admin/onboard.py
@@ -171,8 +171,6 @@ def do_onboard(options):
         HSMCertificateElement({
             "name": "attestation",
             "message": attestation_key_info["message"],
-            "extract": "1:",
-            "digest": HSMCertificateElement.DIGEST.NONE,
             "signature": attestation_key_info["signature"],
             "signed_by": "device",
         }))
@@ -180,8 +178,6 @@ def do_onboard(options):
         HSMCertificateElement({
             "name": "device",
             "message": device_key_info["message"],
-            "extract": "-65:",
-            "digest": HSMCertificateElement.DIGEST.NONE,
             "signature": device_key_info["signature"],
             "signed_by": "root",
         }))


### PR DESCRIPTION
Preventing attestation malleability
    
- Removed `extract` and `digest` fields from attestation file format
- Attestation file specification now includes predefined values for "extract"
- Updated attestation generation and validation
- Updated attestation documentation