### PR TITLE
#36 - Fix Coinspect findings

### DIFF
--- a/ledger/src/signer/src/bc_advance.c
+++ b/ledger/src/signer/src/bc_advance.c
@@ -200,7 +200,10 @@ static void validate_merkle_proof() {
  */
 static void compute_cb_txn_hash() {
     memset(block.wa_buf, 0, CB_MIDSTATE_PREFIX);
-    memcpy(block.wa_buf + CB_MIDSTATE_PREFIX, block.cb_txn, CB_MIDSTATE_DATA);
+    SAFE_MEMMOVE(block.wa_buf, sizeof(block.wa_buf), CB_MIDSTATE_PREFIX,
+                block.cb_txn, MAX_CB_TXN_SIZE, 0,
+                CB_MIDSTATE_DATA,
+                FAIL(BUFFER_OVERFLOW));
     memset(block.wa_buf + CB_MIDSTATE_PREFIX + CB_MIDSTATE_DATA,
            0,
            CB_MIDSTATE_SUFFIX);

--- a/ledger/src/signer/src/bc_diff.c
+++ b/ledger/src/signer/src/bc_diff.c
@@ -25,7 +25,9 @@
 #include <string.h>
 
 #include "bc_diff.h"
+#include "bc_err.h"
 #include "dbg.h"
+#include "memutil.h"
 
 /*
  * Initialize a big integer. This is kind of tricky because the way big
@@ -175,6 +177,10 @@ diff_result check_difficulty(DIGIT_T difficulty[], const uint8_t* mm_hdr_hash) {
 DIGIT_T accum_difficulty(DIGIT_T difficulty[], DIGIT_T total_difficulty[]) {
     DIGIT_T aux[BIGINT_LEN];
     DIGIT_T carry = mpAdd(aux, difficulty, total_difficulty, BIGINT_LEN);
-    memcpy(total_difficulty, aux, sizeof(DIGIT_T) * BIGINT_LEN);
+    SAFE_MEMMOVE(total_difficulty, sizeof(DIGIT_T) * BIGINT_LEN, 0,
+                aux, sizeof(aux), 0,
+                sizeof(DIGIT_T) * BIGINT_LEN,
+                FAIL(BUFFER_OVERFLOW));
+
     return carry;
 }

--- a/ledger/src/signer/src/btctx.c
+++ b/ledger/src/signer/src/btctx.c
@@ -25,7 +25,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "bc_err.h"
 #include "btctx.h"
+#include "memutil.h"
 
 #include "svarint.h"
 
@@ -87,7 +89,10 @@ uint8_t btctx_consume(uint8_t *buf, const uint8_t len) {
             if (svarint_notstarted())
                 ctx->raw_size = 0;
             processed = svarint_consume(buf + i, len - i);
-            memcpy(ctx->raw, buf + i, processed);
+            SAFE_MEMMOVE(ctx->raw, BTCTX_MAX_RAW_SIZE, 0,
+                        buf, len, i,
+                        processed,
+                        FAIL(BUFFER_OVERFLOW));
             ctx->raw_size += processed;
             i += processed - 1;
 

--- a/ledger/src/signer/src/pathAuth.c
+++ b/ledger/src/signer/src/pathAuth.c
@@ -24,6 +24,8 @@
 
 #include <string.h>
 #include <stdbool.h>
+#include "bc_err.h"
+#include "memutil.h"
 #include "pathAuth.h"
 
 /* Paths that require authorization
@@ -87,7 +89,10 @@ bool pathRequireAuth(unsigned char *path) {
     for (unsigned int i = 0; i < sizeof(authPaths) / sizeof(authPaths[0]);
          i++) {
         // Dont memcmp flash to RAM
-        memcpy(cmpbuf, authPaths[i], sizeof(cmpbuf));
+        SAFE_MEMMOVE(cmpbuf, sizeof(cmpbuf), 0,
+                    authPaths[i], sizeof(authPaths[i]), 0,
+                    sizeof(cmpbuf),
+                    FAIL(BUFFER_OVERFLOW));
         if (!memcmp(path, cmpbuf, sizeof(cmpbuf)))
             return true;
     }
@@ -102,7 +107,10 @@ bool pathDontRequireAuth(unsigned char *path) {
     for (unsigned int i = 0; i < sizeof(noAuthPaths) / sizeof(noAuthPaths[0]);
          i++) {
         // Dont memcmp flash to RAM
-        memcpy(cmpbuf, noAuthPaths[i], sizeof(cmpbuf));
+        SAFE_MEMMOVE(cmpbuf, sizeof(cmpbuf), 0,
+                    noAuthPaths[i], sizeof(noAuthPaths[i]), 0,
+                    sizeof(cmpbuf),
+                    FAIL(BUFFER_OVERFLOW));
         if (!memcmp(path, cmpbuf, sizeof(cmpbuf)))
             return true;
     }

--- a/ledger/src/signer/test/difficulty/Makefile
+++ b/ledger/src/signer/test/difficulty/Makefile
@@ -21,7 +21,9 @@
 # SOFTWARE.
 
 SRCDIR = ../../src
-CFLAGS = -I $(SRCDIR) -DFEDHM_EMULATOR -DDEBUG_DIFF
+COMMONPATH = ../../../common/src ../../../common/test/memutil
+
+CFLAGS = -I $(SRCDIR) -I $(COMMONPATH) -DFEDHM_EMULATOR -DDEBUG_DIFF
 
 PROG = test.out
 OBJS = bigdigits.o bc_diff.o test_difficulty.o

--- a/ledger/src/tcpsigner/hsmsim_admin.c
+++ b/ledger/src/tcpsigner/hsmsim_admin.c
@@ -38,17 +38,22 @@ bool hsmsim_admin_need_process(unsigned int rx) {
     return APDU_CLA() == HSMSIM_ADMIN_CLA;
 }
 
-static unsigned int hsmsim_admin_ok(unsigned int tx) {
-    G_io_apdu_buffer[tx++] = 0x90;
-    G_io_apdu_buffer[tx++] = 0x00;
-    return tx;
-}
-
 static unsigned int hsmsim_admin_error(uint16_t code) {
     unsigned int tx = 0;
     G_io_apdu_buffer[tx++] = HSMSIM_ADMIN_CLA;
     SET_APDU_AT(tx++, code >> 8);
     SET_APDU_AT(tx++, code);
+    return tx;
+}
+
+static unsigned int hsmsim_admin_ok(unsigned int tx) {
+    if ((tx + 2 * sizeof(G_io_apdu_buffer[0])) > sizeof(G_io_apdu_buffer)) {
+        info("ADMIN: tx exceeds G_io_apdu_buffer size.\n");
+        return hsmsim_admin_error(HSMSIM_ADMIN_ERROR_DATA_SIZE);
+    }
+
+    G_io_apdu_buffer[tx++] = 0x90;
+    G_io_apdu_buffer[tx++] = 0x00;
     return tx;
 }
 


### PR DESCRIPTION
  - Using SAFE_MEMMOVE instead of memcpy
  - Check tx parameter for G_io_apdu_buffer bounds