### PR TITLE
Fix: blockchain state initialized flag not being properly persisted

### DIFF
--- a/ledger/src/signer/src/bc_state.c
+++ b/ledger/src/signer/src/bc_state.c
@@ -66,7 +66,8 @@ uint8_t INITIAL_BLOCK_HASH[HASHLEN];
 // Non-volatile initialization flag.
 // Linker rules are different in emulator and Ledger mode.
 // When running in emulator mode we must avoid the const.
-NON_VOLATILE bool N_bc_initialized = 0;
+static NON_VOLATILE uint8_t N_bc_initialized_var[1] = {0};
+#define N_bc_initialized (((uint8_t*)PIC(N_bc_initialized_var))[0])
 
 /*
  * Initialize blockchain state.
@@ -77,8 +78,8 @@ void bc_init_state() {
         NVM_WRITE(N_bc_state.best_block, INITIAL_BLOCK_HASH, HASH_SIZE);
         NVM_WRITE(N_bc_state.newest_valid_block, INITIAL_BLOCK_HASH, HASH_SIZE);
 
-        bool b = true;
-        NVM_WRITE(&N_bc_initialized, &b, sizeof(b));
+        uint8_t t = 1;
+        NVM_WRITE(&N_bc_initialized, &t, sizeof(t));
     }
 }
 

--- a/ledger/src/signer/src/runtime.h
+++ b/ledger/src/signer/src/runtime.h
@@ -26,9 +26,9 @@
 #define __RUNTIME
 
 #ifdef HSM_SIMULATOR
-#define NON_VOLATILE static
+#define NON_VOLATILE
 #else
-#define NON_VOLATILE static const
+#define NON_VOLATILE const
 #endif
 
 #endif

--- a/ledger/test/cases/get.py
+++ b/ledger/test/cases/get.py
@@ -40,6 +40,6 @@ class GetBlockchainState(TestCase):
                 for key in self.expected:
                     if state.get(key) != self.expected[key]:
                         raise TestCaseError(f"Expected {key} to be {self.expected[key]} "
-                                            "but got {state.get(key)}")
+                                            f"but got {state.get(key)}")
         except RuntimeError as e:
             raise TestCaseError(str(e))


### PR DESCRIPTION
This was causing a blockchain state reset every time the signer app was opened.