### PR TITLE
Overflow checks on APDU response writes both for UI and Signer

### DIFF
--- a/ledger/src/common/src/apdu.h
+++ b/ledger/src/common/src/apdu.h
@@ -59,6 +59,10 @@
 
 // Total size of APDU data part
 #define APDU_TOTAL_DATA_SIZE (sizeof(G_io_apdu_buffer) - DATA)
+// Total size of APDU data part for outputting
+// (need to leave space for result code)
+#define APDU_RESULT_CODE_SIZE 2
+#define APDU_TOTAL_DATA_SIZE_OUT (APDU_TOTAL_DATA_SIZE - APDU_RESULT_CODE_SIZE)
 
 // Size of payload in APDU
 #define APDU_DATA_SIZE(rx) ((rx) >= DATA ? (rx)-DATA : 0)

--- a/ledger/src/signer/src/auth.c
+++ b/ledger/src/signer/src/auth.c
@@ -92,7 +92,7 @@ unsigned int auth_sign(volatile unsigned int rx) {
                  auth.sig_hash,
                  sizeof(auth.sig_hash),
                  APDU_DATA_PTR,
-                 APDU_TOTAL_DATA_SIZE);
+                 APDU_TOTAL_DATA_SIZE_OUT);
 
     // Error signing?
     if (tx == DO_SIGN_ERROR) {

--- a/ledger/src/signer/src/bc_advance.c
+++ b/ledger/src/signer/src/bc_advance.c
@@ -1031,7 +1031,7 @@ unsigned int bc_advance(volatile unsigned int rx) {
  */
 static uint8_t dump_min_req_difficulty(int offset) {
     // Make sure the minimum required difficulty fits into the output buffer
-    if (APDU_TOTAL_DATA_SIZE < sizeof(MIN_REQUIRED_DIFFICULTY) + offset)
+    if (APDU_TOTAL_DATA_SIZE_OUT < sizeof(MIN_REQUIRED_DIFFICULTY) + offset)
         FAIL(BUFFER_OVERFLOW);
     dump_bigint(APDU_DATA_PTR + offset, MIN_REQUIRED_DIFFICULTY, BIGINT_LEN);
     return sizeof(MIN_REQUIRED_DIFFICULTY);

--- a/ledger/src/signer/src/bc_state.c
+++ b/ledger/src/signer/src/bc_state.c
@@ -124,7 +124,7 @@ uint8_t dump_hash(uint8_t hash_code) {
 
     APDU_DATA_PTR[0] = hash_code;
     SAFE_MEMMOVE(APDU_DATA_PTR,
-                 APDU_TOTAL_DATA_SIZE,
+                 APDU_TOTAL_DATA_SIZE_OUT,
                  1,
                  h,
                  HASH_SIZE,
@@ -149,7 +149,7 @@ uint8_t dump_difficulty() {
     for (; start < sizeof(buf) && buf[start] == 0; start++)
         continue;
     SAFE_MEMMOVE(APDU_DATA_PTR,
-                 APDU_TOTAL_DATA_SIZE,
+                 APDU_TOTAL_DATA_SIZE_OUT,
                  MEMMOVE_ZERO_OFFSET,
                  buf,
                  sizeof(buf),
@@ -167,7 +167,7 @@ uint8_t dump_difficulty() {
  */
 uint8_t bc_dump_initial_block_hash(int offset) {
     SAFE_MEMMOVE(APDU_DATA_PTR,
-                 APDU_TOTAL_DATA_SIZE,
+                 APDU_TOTAL_DATA_SIZE_OUT,
                  offset,
                  INITIAL_BLOCK_HASH,
                  sizeof(INITIAL_BLOCK_HASH),

--- a/ledger/src/signer/src/hsm.c
+++ b/ledger/src/signer/src/hsm.c
@@ -131,7 +131,7 @@ unsigned int hsm_process_apdu(volatile unsigned int rx) {
                      sizeof(auth.path),
                      MEMMOVE_ZERO_OFFSET,
                      APDU_DATA_PTR,
-                     APDU_TOTAL_DATA_SIZE,
+                     APDU_TOTAL_DATA_SIZE_OUT,
                      MEMMOVE_ZERO_OFFSET,
                      RSK_PATH_LEN * sizeof(uint32_t),
                      THROW(0x6A8F));
@@ -216,6 +216,11 @@ unsigned int hsm_process_exception(unsigned short code, unsigned int tx) {
     }
 
     // Append resulting code to APDU
+    // (check for a potential overflow first)
+    if (tx + 2 > sizeof(G_io_apdu_buffer)) {
+        tx = 0;
+        sw = 0x6983;
+    }
     SET_APDU_AT(tx++, sw >> 8);
     SET_APDU_AT(tx++, sw);
 

--- a/ledger/src/ui/src/attestation.c
+++ b/ledger/src/ui/src/attestation.c
@@ -33,7 +33,7 @@
 
 // Utility macros to save memory
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
-#define PAGESIZE (APDU_TOTAL_DATA_SIZE - 1)
+#define PAGESIZE (APDU_TOTAL_DATA_SIZE_OUT - 1)
 #define PAGECOUNT(itemcount) (((itemcount) + PAGESIZE - 1) / PAGESIZE)
 
 // Global onboarding flag
@@ -70,7 +70,7 @@ static void check_stage(att_t* att_ctx, att_stage_t expected) {
  * large enough and are just sanity checking
  */
 static void check_apdu_buffer_holds(size_t size) {
-    if (APDU_TOTAL_DATA_SIZE < size) {
+    if (APDU_TOTAL_DATA_SIZE_OUT < size) {
         THROW(INTERNAL);
     }
 }
@@ -279,7 +279,7 @@ unsigned int get_attestation(volatile unsigned int rx, att_t* att_ctx) {
         message_size =
             MIN(PAGESIZE, att_ctx->msg_offset - (APDU_DATA_PTR[0] * PAGESIZE));
         SAFE_MEMMOVE(APDU_DATA_PTR,
-                     APDU_TOTAL_DATA_SIZE,
+                     APDU_TOTAL_DATA_SIZE_OUT,
                      1,
                      att_ctx->msg,
                      sizeof(att_ctx->msg),

--- a/ledger/src/ui/src/bolos_ux.c
+++ b/ledger/src/ui/src/bolos_ux.c
@@ -701,7 +701,13 @@ static void sample_main(void) {
                     sw = 0x6800 | (e & 0x7FF);
                     break;
                 }
+
                 // Unexpected exception => report
+                // (check for a potential overflow first)
+                if (tx + 2 > sizeof(G_io_apdu_buffer)) {
+                    tx = 0;
+                    sw = 0x6983;
+                }
                 SET_APDU_AT(tx++, sw >> 8);
                 SET_APDU_AT(tx++, sw);
             }

--- a/ledger/src/ui/src/signer_authorization.c
+++ b/ledger/src/ui/src/signer_authorization.c
@@ -187,7 +187,7 @@ unsigned int do_authorize_signer(volatile unsigned int rx,
         sanity_check();
 
         SAFE_MEMMOVE(APDU_DATA_PTR,
-                     APDU_TOTAL_DATA_SIZE,
+                     APDU_TOTAL_DATA_SIZE_OUT,
                      MEMMOVE_ZERO_OFFSET,
                      N_current_signer_status.signer.hash,
                      sizeof(N_current_signer_status.signer.hash),
@@ -195,7 +195,7 @@ unsigned int do_authorize_signer(volatile unsigned int rx,
                      sizeof(N_current_signer_status.signer.hash),
                      THROW(INTERNAL));
 
-        if (APDU_TOTAL_DATA_SIZE <
+        if (APDU_TOTAL_DATA_SIZE_OUT <
             sizeof(N_current_signer_status.signer.hash) +
                 sizeof(N_current_signer_status.signer.iteration))
             THROW(INTERNAL);
@@ -313,7 +313,7 @@ unsigned int do_authorize_signer(volatile unsigned int rx,
             THROW(SIG_AUT_INVALID_AUTH_INVALID_INDEX);
 
         SAFE_MEMMOVE(APDU_DATA_PTR,
-                     APDU_TOTAL_DATA_SIZE,
+                     APDU_TOTAL_DATA_SIZE_OUT,
                      MEMMOVE_ZERO_OFFSET,
                      authorizers_pubkeys[auth_index],
                      sizeof(authorizers_pubkeys[auth_index]),


### PR DESCRIPTION
- Added overflow checks
- Differentiated between total APDU data part size for reading and writing operations
- Used new total APDU data part size for writing throughout