### PR TITLE
TCPSigner enhancements

### DIFF
--- a/ledger/src/tcpsigner/dbg.c
+++ b/ledger/src/tcpsigner/dbg.c
@@ -40,6 +40,7 @@
 void LOG_HEX(const char *prefix, void *buffer, size_t size) {
     printf("%s ", prefix);
     if (size > 0) {
+        printf("0x");
         for (unsigned int i = 0; i < size; i++) {
             printf("%02x", ((unsigned char *)buffer)[i]);
         }
@@ -65,7 +66,7 @@ void LOG_BIGD_HEX(const char *prefix,
     if (0 == len)
         len = 1;
     /* print first digit without leading zeros */
-    printf("%" PRIxBIGD, a[--len]);
+    printf("0x%" PRIxBIGD, a[--len]);
     while (len--) {
         printf("%08" PRIxBIGD, a[len]);
     }

--- a/ledger/src/tcpsigner/hsmsim_nu.c
+++ b/ledger/src/tcpsigner/hsmsim_nu.c
@@ -37,12 +37,8 @@ static DIGIT_T MAX_BLOCK_DIFFICULTY_MAINNET[BIGINT_LEN] = BCDIFF_MBD_MAINNET;
 static DIGIT_T MAX_BLOCK_DIFFICULTY_TESTNET[BIGINT_LEN] = BCDIFF_MBD_TESTNET;
 static DIGIT_T MAX_BLOCK_DIFFICULTY_REGTEST[BIGINT_LEN] = BCDIFF_MBD_REGTEST;
 
-typedef struct network_upgrade_activation_s {
-    network_upgrade_t network_upgrade;
-    uint32_t activation_bn;
-} network_upgrade_activation_t;
-
-static const network_upgrade_activation_t NETCONFIG_REGTEST[] = {{NU_IRIS, 0}};
+static const network_upgrade_activation_t NETCONFIG_REGTEST[] = {
+    {NU_WASABI, 0}, {NU_PAPYRUS, 0}, {NU_IRIS, 0}};
 
 static const network_upgrade_activation_t NETCONFIG_TESTNET[] = {
     {NU_WASABI, TESTNET_WASABI_ABN},
@@ -55,7 +51,8 @@ static const network_upgrade_activation_t NETCONFIG_MAINNET[] = {
     {NU_PAPYRUS, MAINNET_PAPYRUS_ABN},
     {NU_IRIS, MAINNET_IRIS_ABN}};
 
-static const network_upgrade_activation_t* network_upgrade_activations;
+static network_upgrade_activation_t
+    network_upgrade_activations[MAX_NETWORK_UPGRADE_ACTIVATIONS];
 static unsigned int network_upgrade_activations_count;
 
 static uint8_t network_identifier;
@@ -106,9 +103,10 @@ uint8_t get_network_identifier_by_name(char* name) {
 
 bool hsmsim_set_network(uint8_t netid) {
     network_identifier = netid;
+    const network_upgrade_activation_t* activations;
     switch (netid) {
     case NETID_MAINNET:
-        network_upgrade_activations = NETCONFIG_MAINNET;
+        activations = NETCONFIG_MAINNET;
         network_upgrade_activations_count =
             sizeof(NETCONFIG_MAINNET) / sizeof(NETCONFIG_MAINNET[0]);
         memmove(MAX_BLOCK_DIFFICULTY,
@@ -116,7 +114,7 @@ bool hsmsim_set_network(uint8_t netid) {
                 sizeof(MAX_BLOCK_DIFFICULTY_MAINNET));
         break;
     case NETID_TESTNET:
-        network_upgrade_activations = NETCONFIG_TESTNET;
+        activations = NETCONFIG_TESTNET;
         network_upgrade_activations_count =
             sizeof(NETCONFIG_TESTNET) / sizeof(NETCONFIG_TESTNET[0]);
         memmove(MAX_BLOCK_DIFFICULTY,
@@ -124,7 +122,7 @@ bool hsmsim_set_network(uint8_t netid) {
                 sizeof(MAX_BLOCK_DIFFICULTY_TESTNET));
         break;
     case NETID_REGTEST:
-        network_upgrade_activations = NETCONFIG_REGTEST;
+        activations = NETCONFIG_REGTEST;
         network_upgrade_activations_count =
             sizeof(NETCONFIG_REGTEST) / sizeof(NETCONFIG_REGTEST[0]);
         memmove(MAX_BLOCK_DIFFICULTY,
@@ -134,5 +132,52 @@ bool hsmsim_set_network(uint8_t netid) {
     default:
         return false;
     }
+
+    // Copy activations
+    memset(network_upgrade_activations, 0, sizeof(network_upgrade_activations));
+    for (int i = 0; i < network_upgrade_activations_count; i++) {
+        network_upgrade_activations[i].activation_bn =
+            activations[i].activation_bn;
+        network_upgrade_activations[i].network_upgrade =
+            activations[i].network_upgrade;
+    }
+
     return true;
+}
+
+bool hsmsim_set_network_upgrade_block_number(
+    network_upgrade_activation_t network_upgrade_activation) {
+    for (int i = 0; i < network_upgrade_activations_count; i++) {
+        if (network_upgrade_activations[i].network_upgrade ==
+            network_upgrade_activation.network_upgrade) {
+            network_upgrade_activations[i].activation_bn =
+                network_upgrade_activation.activation_bn;
+            return true;
+        }
+    }
+    return false;
+}
+
+int hsmsim_get_network_upgrade_activations_count() {
+    return network_upgrade_activations_count;
+}
+
+network_upgrade_activation_t* hsmsim_get_network_upgrade_activations() {
+    return network_upgrade_activations;
+}
+
+char* hsmsim_get_network_upgrade_name(network_upgrade_t nu) {
+    switch (nu) {
+    case NU_ANCIENT:
+        return "Ancient";
+    case NU_WASABI:
+        return "Wasabi";
+    case NU_PAPYRUS:
+        return "Papyrus";
+    case NU_IRIS:
+        return "Iris";
+    case NU_UNKNOWN:
+    default:
+        return "Unknown";
+    }
 }

--- a/ledger/src/tcpsigner/hsmsim_nu.h
+++ b/ledger/src/tcpsigner/hsmsim_nu.h
@@ -29,6 +29,14 @@
 
 #include "bc_nu.h"
 
+// Update as more network upgrades come up
+#define MAX_NETWORK_UPGRADE_ACTIVATIONS 4
+
+typedef struct network_upgrade_activation_s {
+    network_upgrade_t network_upgrade;
+    uint32_t activation_bn;
+} network_upgrade_activation_t;
+
 void hsmsim_set_network_upgrade(uint32_t block_number,
                                 uint8_t* dst_network_upgrade);
 
@@ -39,5 +47,14 @@ const char* get_network_name(uint8_t netid);
 uint8_t get_network_identifier_by_name(char* name);
 
 bool hsmsim_set_network(uint8_t netid);
+
+bool hsmsim_set_network_upgrade_block_number(
+    network_upgrade_activation_t network_upgrade_activation);
+
+int hsmsim_get_network_upgrade_activations_count();
+
+network_upgrade_activation_t* hsmsim_get_network_upgrade_activations();
+
+char* hsmsim_get_network_upgrade_name(network_upgrade_t nu);
 
 #endif // __SIMULATOR_NU

--- a/ledger/src/tcpsigner/log.c
+++ b/ledger/src/tcpsigner/log.c
@@ -50,3 +50,8 @@ void info_hex(const char *prefix, void *buffer, size_t size) {
     LOG(PREFIX);
     LOG_HEX(prefix, buffer, size);
 }
+
+void info_bigd_hex(const char *prefix, const DIGIT_T *a, size_t len) {
+    LOG(PREFIX);
+    LOG_BIGD_HEX(prefix, a, len, "\n");
+}

--- a/ledger/src/tcpsigner/log.h
+++ b/ledger/src/tcpsigner/log.h
@@ -31,7 +31,10 @@
 #ifndef __SIMULATOR_LOG
 #define __SIMULATOR_LOG
 
+#include "bigdigits.h"
+
 void info(const char *format, ...);
 void info_hex(const char *prefix, void *buffer, size_t size);
+void info_bigd_hex(const char *prefix, const DIGIT_T *a, size_t len);
 
 #endif // __SIMULATOR_LOG

--- a/middleware/admin/verify_attestation.py
+++ b/middleware/admin/verify_attestation.py
@@ -168,9 +168,10 @@ def do_verify_attestation(options):
             f"Invalid Signer attestation message header: {signer_message[:mh_len].hex()}")
 
     if signer_message[mh_len:] != pubkeys_hash:
+        reported = signer_message[mh_len:].hex()
         raise AdminError(
             f"Signer attestation public keys hash mismatch: expected {pubkeys_hash.hex()}"
-            f" but attestation reports {signer_message[mh_len:].hex()}"
+            f" but attestation reports {reported}"
         )
 
     head(


### PR DESCRIPTION
- Allowing command-line customisation of block difficulty cap
- Allowing command-line customisation of network upgrade activation block numbers
- Adding '0x' prefixes to informational hex output
- Fixing command-line difficulty validation bug
- Incidentally fixing middleware attestation verification error message format