### PR TITLE
3.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,11 @@
 # Changelog
 
-## [3.0.0] - 04/06/2022
+## [3.0.2] - 29/09/2022
 
 ### Features/enhancements
 
-- Considering uncles difficulty in "advanceBlockchain" operation
-- Implemented N of M signer upgrade authorization scheme
-- Authorized signing operation parsers rewritten from scratch
-- Added new "blockchainParameters" command
-- Added unit tests to middleware admin tooling
-- Fuzzing improvements
-- General best practices related improvements and fixes
-- Removed old/unused code
-
-### Fixes
-
-- Fixed failing middleware docker image build
+- TCPSigner: added command-line customisation of block difficulty cap and network upgrade activation block numbers
+- Added support for building and running the TCPSigner bundle on arm64
 
 ## [3.0.1] - 11/08/2022
 
@@ -49,3 +39,20 @@
 - Persistence issue with blockchain state initialization flag
 - Fixed attestation documentation broken links
 - Fixed CHANGELOG 3.0.0 version and release date
+
+## [3.0.0] - 04/06/2022
+
+### Features/enhancements
+
+- Considering uncles difficulty in "advanceBlockchain" operation
+- Implemented N of M signer upgrade authorization scheme
+- Authorized signing operation parsers rewritten from scratch
+- Added new "blockchainParameters" command
+- Added unit tests to middleware admin tooling
+- Fuzzing improvements
+- General best practices related improvements and fixes
+- Removed old/unused code
+
+### Fixes
+
+- Fixed failing middleware docker image build

--- a/ledger/src/signer/src/defs.h
+++ b/ledger/src/signer/src/defs.h
@@ -30,7 +30,7 @@
 // Version and patchlevel
 #define VERSION_MAJOR 0x03
 #define VERSION_MINOR 0x00
-#define VERSION_PATCH 0x01
+#define VERSION_PATCH 0x02
 
 // Instructions
 #define INS_SIGN 0x02

--- a/ledger/src/ui/src/defs.h
+++ b/ledger/src/ui/src/defs.h
@@ -30,7 +30,7 @@
 // Version and patchlevel
 #define VERSION_MAJOR 0x03
 #define VERSION_MINOR 0x00
-#define VERSION_PATCH 0x01
+#define VERSION_PATCH 0x02
 
 // Instructions
 #define RSK_PIN_CMD 0x41

--- a/middleware/ledger/protocol.py
+++ b/middleware/ledger/protocol.py
@@ -36,8 +36,8 @@ from comm.bitcoin import get_unsigned_tx, get_tx_hash
 
 class HSM2ProtocolLedger(HSM2Protocol):
     # Current manager supported versions for HSM UI and HSM SIGNER (<=)
-    UI_VERSION = HSM2FirmwareVersion(3, 0, 1)
-    APP_VERSION = HSM2FirmwareVersion(3, 0, 1)
+    UI_VERSION = HSM2FirmwareVersion(3, 0, 2)
+    APP_VERSION = HSM2FirmwareVersion(3, 0, 2)
 
     # Amount of time to wait to make sure the app is opened
     OPEN_APP_WAIT = 1  # second


### PR DESCRIPTION
- Bumping UI, Signer and Middleware versions
- Updating CHANGELOG
- Fixed order of previous CHANGELOG entries