### PR TITLE
TCPSigner enhancements

### DIFF
--- a/ledger/src/tcpsigner/dbg.c
+++ b/ledger/src/tcpsigner/dbg.c
@@ -40,6 +40,7 @@
 void LOG_HEX(const char *prefix, void *buffer, size_t size) {
     printf("%s ", prefix);
     if (size > 0) {
+        printf("0x");
         for (unsigned int i = 0; i < size; i++) {
             printf("%02x", ((unsigned char *)buffer)[i]);
         }
@@ -65,7 +66,7 @@ void LOG_BIGD_HEX(const char *prefix,
     if (0 == len)
         len = 1;
     /* print first digit without leading zeros */
-    printf("%" PRIxBIGD, a[--len]);
+    printf("0x%" PRIxBIGD, a[--len]);
     while (len--) {
         printf("%08" PRIxBIGD, a[len]);
     }

--- a/ledger/src/tcpsigner/hsmsim_nu.c
+++ b/ledger/src/tcpsigner/hsmsim_nu.c
@@ -37,12 +37,8 @@ static DIGIT_T MAX_BLOCK_DIFFICULTY_MAINNET[BIGINT_LEN] = BCDIFF_MBD_MAINNET;
 static DIGIT_T MAX_BLOCK_DIFFICULTY_TESTNET[BIGINT_LEN] = BCDIFF_MBD_TESTNET;
 static DIGIT_T MAX_BLOCK_DIFFICULTY_REGTEST[BIGINT_LEN] = BCDIFF_MBD_REGTEST;
 
-typedef struct network_upgrade_activation_s {
-    network_upgrade_t network_upgrade;
-    uint32_t activation_bn;
-} network_upgrade_activation_t;
-
-static const network_upgrade_activation_t NETCONFIG_REGTEST[] = {{NU_IRIS, 0}};
+static const network_upgrade_activation_t NETCONFIG_REGTEST[] = {
+    {NU_WASABI, 0}, {NU_PAPYRUS, 0}, {NU_IRIS, 0}};
 
 static const network_upgrade_activation_t NETCONFIG_TESTNET[] = {
     {NU_WASABI, TESTNET_WASABI_ABN},
@@ -55,7 +51,8 @@ static const network_upgrade_activation_t NETCONFIG_MAINNET[] = {
     {NU_PAPYRUS, MAINNET_PAPYRUS_ABN},
     {NU_IRIS, MAINNET_IRIS_ABN}};
 
-static const network_upgrade_activation_t* network_upgrade_activations;
+static network_upgrade_activation_t
+    network_upgrade_activations[MAX_NETWORK_UPGRADE_ACTIVATIONS];
 static unsigned int network_upgrade_activations_count;
 
 static uint8_t network_identifier;
@@ -106,9 +103,10 @@ uint8_t get_network_identifier_by_name(char* name) {
 
 bool hsmsim_set_network(uint8_t netid) {
     network_identifier = netid;
+    const network_upgrade_activation_t* activations;
     switch (netid) {
     case NETID_MAINNET:
-        network_upgrade_activations = NETCONFIG_MAINNET;
+        activations = NETCONFIG_MAINNET;
         network_upgrade_activations_count =
             sizeof(NETCONFIG_MAINNET) / sizeof(NETCONFIG_MAINNET[0]);
         memmove(MAX_BLOCK_DIFFICULTY,
@@ -116,7 +114,7 @@ bool hsmsim_set_network(uint8_t netid) {
                 sizeof(MAX_BLOCK_DIFFICULTY_MAINNET));
         break;
     case NETID_TESTNET:
-        network_upgrade_activations = NETCONFIG_TESTNET;
+        activations = NETCONFIG_TESTNET;
         network_upgrade_activations_count =
             sizeof(NETCONFIG_TESTNET) / sizeof(NETCONFIG_TESTNET[0]);
         memmove(MAX_BLOCK_DIFFICULTY,
@@ -124,7 +122,7 @@ bool hsmsim_set_network(uint8_t netid) {
                 sizeof(MAX_BLOCK_DIFFICULTY_TESTNET));
         break;
     case NETID_REGTEST:
-        network_upgrade_activations = NETCONFIG_REGTEST;
+        activations = NETCONFIG_REGTEST;
         network_upgrade_activations_count =
             sizeof(NETCONFIG_REGTEST) / sizeof(NETCONFIG_REGTEST[0]);
         memmove(MAX_BLOCK_DIFFICULTY,
@@ -134,5 +132,52 @@ bool hsmsim_set_network(uint8_t netid) {
     default:
         return false;
     }
+
+    // Copy activations
+    memset(network_upgrade_activations, 0, sizeof(network_upgrade_activations));
+    for (int i = 0; i < network_upgrade_activations_count; i++) {
+        network_upgrade_activations[i].activation_bn =
+            activations[i].activation_bn;
+        network_upgrade_activations[i].network_upgrade =
+            activations[i].network_upgrade;
+    }
+
     return true;
+}
+
+bool hsmsim_set_network_upgrade_block_number(
+    network_upgrade_activation_t network_upgrade_activation) {
+    for (int i = 0; i < network_upgrade_activations_count; i++) {
+        if (network_upgrade_activations[i].network_upgrade ==
+            network_upgrade_activation.network_upgrade) {
+            network_upgrade_activations[i].activation_bn =
+                network_upgrade_activation.activation_bn;
+            return true;
+        }
+    }
+    return false;
+}
+
+int hsmsim_get_network_upgrade_activations_count() {
+    return network_upgrade_activations_count;
+}
+
+network_upgrade_activation_t* hsmsim_get_network_upgrade_activations() {
+    return network_upgrade_activations;
+}
+
+char* hsmsim_get_network_upgrade_name(network_upgrade_t nu) {
+    switch (nu) {
+    case NU_ANCIENT:
+        return "Ancient";
+    case NU_WASABI:
+        return "Wasabi";
+    case NU_PAPYRUS:
+        return "Papyrus";
+    case NU_IRIS:
+        return "Iris";
+    case NU_UNKNOWN:
+    default:
+        return "Unknown";
+    }
 }

--- a/ledger/src/tcpsigner/hsmsim_nu.h
+++ b/ledger/src/tcpsigner/hsmsim_nu.h
@@ -29,6 +29,14 @@
 
 #include "bc_nu.h"
 
+// Update as more network upgrades come up
+#define MAX_NETWORK_UPGRADE_ACTIVATIONS 4
+
+typedef struct network_upgrade_activation_s {
+    network_upgrade_t network_upgrade;
+    uint32_t activation_bn;
+} network_upgrade_activation_t;
+
 void hsmsim_set_network_upgrade(uint32_t block_number,
                                 uint8_t* dst_network_upgrade);
 
@@ -39,5 +47,14 @@ const char* get_network_name(uint8_t netid);
 uint8_t get_network_identifier_by_name(char* name);
 
 bool hsmsim_set_network(uint8_t netid);
+
+bool hsmsim_set_network_upgrade_block_number(
+    network_upgrade_activation_t network_upgrade_activation);
+
+int hsmsim_get_network_upgrade_activations_count();
+
+network_upgrade_activation_t* hsmsim_get_network_upgrade_activations();
+
+char* hsmsim_get_network_upgrade_name(network_upgrade_t nu);
 
 #endif // __SIMULATOR_NU

--- a/ledger/src/tcpsigner/log.c
+++ b/ledger/src/tcpsigner/log.c
@@ -50,3 +50,8 @@ void info_hex(const char *prefix, void *buffer, size_t size) {
     LOG(PREFIX);
     LOG_HEX(prefix, buffer, size);
 }
+
+void info_bigd_hex(const char *prefix, const DIGIT_T *a, size_t len) {
+    LOG(PREFIX);
+    LOG_BIGD_HEX(prefix, a, len, "\n");
+}

--- a/ledger/src/tcpsigner/log.h
+++ b/ledger/src/tcpsigner/log.h
@@ -31,7 +31,10 @@
 #ifndef __SIMULATOR_LOG
 #define __SIMULATOR_LOG
 
+#include "bigdigits.h"
+
 void info(const char *format, ...);
 void info_hex(const char *prefix, void *buffer, size_t size);
+void info_bigd_hex(const char *prefix, const DIGIT_T *a, size_t len);
 
 #endif // __SIMULATOR_LOG

--- a/ledger/src/tcpsigner/tcpsigner.c
+++ b/ledger/src/tcpsigner/tcpsigner.c
@@ -48,10 +48,17 @@
 #include "hsm-ledger.h"
 #include "bc_advance.h"
 #include "bc_state.h"
+#include "bc_diff.h"
 
 #include "hex_reader.h"
 
 #include "log.h"
+
+typedef enum {
+    ARG_NU_WASABI = 0xaa00,
+    ARG_NU_PAPYRUS,
+    ARG_NU_IRIS,
+} arg_non_printable_t;
 
 // Argp option spec
 static struct argp_option options[] = {
@@ -60,11 +67,27 @@ static struct argp_option options[] = {
     {"port", 'p', "PORT", 0, "Port to listen on"},
     {"checkpoint", 'c', "HASH", 0, "Checkpoint block hash"},
     {"difficulty", 'd', "DIFFICULTY", 0, "Minimum required difficulty"},
+    {"diffcap", 'y', "DIFFICULTYCAP", 0, "Individual block difficulty cap"},
     {"network", 'n', "NETWORK", 0, "Network to use"},
     {"key", 'k', "KEYFILE", 0, "Private key file to load"},
     {"verbose", 'v', 0, 0, "Produce verbose output"},
     {"inputfile", 'i', "INPUTFILE", 0, "Read input from file"},
     {"replicafile", 'r', "REPLICAFILE", 0, "Copy inputs to this file"},
+    {"nuwasabi",
+     ARG_NU_WASABI,
+     "BLOCKNUMBER",
+     0,
+     "Custom Wasabi activation block number"},
+    {"nupapyrus",
+     ARG_NU_PAPYRUS,
+     "BLOCKNUMBER",
+     0,
+     "Custom Papyrus activation block number"},
+    {"nuiris",
+     ARG_NU_IRIS,
+     "BLOCKNUMBER",
+     0,
+     "Custom Iris activation block number"},
     {0}};
 
 // Argument definitions for argp
@@ -81,10 +104,16 @@ struct arguments {
     uint8_t checkpoint[HASH_SIZE];
     uint8_t difficulty_b[sizeof(DIGIT_T) * BIGINT_LEN];
     DIGIT_T difficulty[BIGINT_LEN];
+    bool have_difficulty_cap;
+    DIGIT_T difficulty_cap[BIGINT_LEN];
     uint8_t network_identifier;
     char inputfile[PATH_MAX];
     char replicafile[PATH_MAX];
     bool filemode;
+    int activation_bn;
+    int network_upgrade_overrides_count;
+    network_upgrade_activation_t
+        network_upgrade_overrides[MAX_NETWORK_UPGRADE_ACTIVATIONS];
 };
 
 // Argp individual option parsing function
@@ -125,8 +154,10 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
         }
         break;
     case 'd':
+    case 'y':
         arguments->difficulty_s = arg;
-        if (strlen(arg) > sizeof(arguments->difficulty_b) * 2 + 2) {
+        offset = (arg[0] == '0' && arg[1] == 'x') ? 2 : 0;
+        if (strlen(arg) > sizeof(arguments->difficulty_b) * 2 + offset) {
             argp_failure(state,
                          1,
                          0,
@@ -134,7 +165,6 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
                          "prefixed with 0x) of at most %u bytes",
                          sizeof(arguments->difficulty_b));
         }
-        offset = (arg[0] == '0' && arg[1] == 'x') ? 2 : 0;
         uint8_t dif_offset =
             sizeof(arguments->difficulty_b) - strlen(arg + offset) / 2;
         if (strlen(arg + offset) < 2 ||
@@ -143,11 +173,22 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
                      arguments->difficulty_b + dif_offset) == -1) {
             argp_failure(state, 1, 0, "Invalid difficulty given: %s", arg);
         }
+        DIGIT_T *dest;
+        uint16_t dest_size;
+        if (key == 'y') {
+            arguments->have_difficulty_cap = true;
+            dest = arguments->difficulty_cap;
+            dest_size = sizeof(arguments->difficulty_cap) /
+                        sizeof(arguments->difficulty_cap[0]);
+        } else {
+            dest = arguments->difficulty;
+            dest_size = sizeof(arguments->difficulty) /
+                        sizeof(arguments->difficulty[0]);
+        }
         bigint(arguments->difficulty_b,
                sizeof(arguments->difficulty_b),
-               arguments->difficulty,
-               sizeof(arguments->difficulty) /
-                   sizeof(arguments->difficulty[0]));
+               dest,
+               dest_size);
         break;
     case 'n':
         arguments->network = arg;
@@ -166,6 +207,24 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
     case 'i':
         strncpy(arguments->inputfile, arg, sizeof(arguments->inputfile) - 1);
         arguments->filemode = true;
+        break;
+    case ARG_NU_WASABI:
+    case ARG_NU_PAPYRUS:
+    case ARG_NU_IRIS:
+        if ((arguments->activation_bn = atoi(arg)) < 0 ||
+            (arguments->activation_bn == 0 && strcmp("0", arg))) {
+            argp_failure(
+                state, 1, 0, "Invalid activation block number given: %s", arg);
+        }
+        arguments
+            ->network_upgrade_overrides[arguments
+                                            ->network_upgrade_overrides_count]
+            .network_upgrade = key - ARG_NU_WASABI + NU_WASABI;
+        arguments
+            ->network_upgrade_overrides[arguments
+                                            ->network_upgrade_overrides_count]
+            .activation_bn = arguments->activation_bn;
+        arguments->network_upgrade_overrides_count++;
         break;
     default:
         return ARGP_ERR_UNKNOWN;
@@ -194,6 +253,12 @@ void main(int argc, char **argv) {
         "attid.json",  // Attestation key file
         false,         // verbose
     };
+
+    // No custom difficulty cap by default
+    arguments.have_difficulty_cap = false;
+
+    // No network upgrade activations overrides by default
+    arguments.network_upgrade_overrides_count = 0;
 
     // Convert default checkpoint
     read_hex(arguments.checkpoint_s,
@@ -228,9 +293,11 @@ void main(int argc, char **argv) {
     info("TCPSigner starting.\n");
 
     info("Signer parameters:\n");
-    info_hex("Checkpoint", arguments.checkpoint, sizeof(arguments.checkpoint));
-    info_hex(
-        "Difficulty", arguments.difficulty_b, sizeof(arguments.difficulty_b));
+    info_hex("Checkpoint:", arguments.checkpoint, sizeof(arguments.checkpoint));
+    info_bigd_hex("Difficulty: ",
+                  arguments.difficulty,
+                  sizeof(arguments.difficulty) /
+                      sizeof(arguments.difficulty[0]));
     info("Network: %s\n", arguments.network);
 
     // Set checkpoint
@@ -242,6 +309,32 @@ void main(int argc, char **argv) {
             sizeof(arguments.difficulty));
     // Set network
     hsmsim_set_network(arguments.network_identifier);
+
+    // Set custom block difficulty cap (if any)
+    if (arguments.have_difficulty_cap) {
+        memmove(MAX_BLOCK_DIFFICULTY,
+                arguments.difficulty_cap,
+                sizeof(arguments.difficulty_cap));
+    }
+    info_bigd_hex("Block difficulty cap: ",
+                  MAX_BLOCK_DIFFICULTY,
+                  sizeof(MAX_BLOCK_DIFFICULTY) /
+                      sizeof(MAX_BLOCK_DIFFICULTY[0]));
+
+    // Set network upgrade activation overrides
+    for (int i = 0; i < arguments.network_upgrade_overrides_count; i++)
+        hsmsim_set_network_upgrade_block_number(
+            arguments.network_upgrade_overrides[i]);
+    // Display network upgrade activation configuration
+    info("Network upgrade activation block numbers (latest takes "
+         "precedence):\n");
+    network_upgrade_activation_t *activations =
+        hsmsim_get_network_upgrade_activations();
+    for (int i = 0; i < hsmsim_get_network_upgrade_activations_count(); i++) {
+        info("\t%s: %u\n",
+             hsmsim_get_network_upgrade_name(activations[i].network_upgrade),
+             activations[i].activation_bn);
+    }
 
     // Initialize ECDSA
     if (!hsmsim_ecdsa_initialize(arguments.key_file_path)) {

--- a/middleware/admin/verify_attestation.py
+++ b/middleware/admin/verify_attestation.py
@@ -168,9 +168,10 @@ def do_verify_attestation(options):
             f"Invalid Signer attestation message header: {signer_message[:mh_len].hex()}")
 
     if signer_message[mh_len:] != pubkeys_hash:
+        reported = signer_message[mh_len:].hex()
         raise AdminError(
             f"Signer attestation public keys hash mismatch: expected {pubkeys_hash.hex()}"
-            f" but attestation reports {signer_message[mh_len:].hex()}"
+            f" but attestation reports {reported}"
         )
 
     head(


### PR DESCRIPTION
- Allowing command-line customisation of block difficulty cap
- Allowing command-line customisation of network upgrade activation block numbers
- Adding '0x' prefixes to informational hex output
- Fixing command-line difficulty validation bug
- Incidentally fixing middleware attestation verification error message format