### PR TITLE
Prevent re-onboarding

### DIFF
--- a/ledger/src/ui/src/bootloader.c
+++ b/ledger/src/ui/src/bootloader.c
@@ -47,6 +47,12 @@ static unsigned char current_cmd;
 // Flag used to prevent executing commands after the onboard is performed
 static bool onboard_performed = false;
 
+// Macro that throws an error unless
+// the device is not onboarded
+#define REQUIRE_NOT_ONBOARDED()      \
+    if (os_perso_isonboarded() == 1) \
+        THROW(ERR_DEVICE_ONBOARDED);
+
 /*
  * Reset all reseteable operations, only if the given operation is starting.
  *
@@ -96,6 +102,7 @@ unsigned int bootloader_process_apdu(volatile unsigned int rx,
     // unauthenticated instruction
     switch (APDU_CMD()) {
     case RSK_SEED_CMD: // Send wordlist
+        REQUIRE_NOT_ONBOARDED();
         reset_if_starting(RSK_META_CMD_UIOP);
         tx = set_host_seed(rx, &onboard_ctx);
         break;
@@ -108,6 +115,7 @@ unsigned int bootloader_process_apdu(volatile unsigned int rx,
         tx = is_onboarded();
         break;
     case RSK_WIPE: //--- wipe and onboard device ---
+        REQUIRE_NOT_ONBOARDED();
         reset_if_starting(RSK_META_CMD_UIOP);
         tx = onboard_device(&onboard_ctx);
         clear_pin();

--- a/ledger/src/ui/src/err.h
+++ b/ledger/src/ui/src/err.h
@@ -31,6 +31,7 @@ typedef enum {
     ERR_INVALID_CLA = 0x6E22,
     ERR_INTERNAL = 0x6A99,
     ERR_INVALID_PIN = 0x69A0,
+    ERR_DEVICE_ONBOARDED = 0x69A1,
 
     EX_BOOTLOADER_RSK_END = 0x90FF,
 } err_code_ui_t;

--- a/middleware/admin/onboard.py
+++ b/middleware/admin/onboard.py
@@ -85,10 +85,9 @@ def do_onboard(options):
     info(f"Onboarded: {bls(is_onboarded)}")
 
     if is_onboarded:
-        message = ("WARNING: The following operation will wipe the device and "
-                   "generate a new seed. This cannot be undone.")
-    else:
-        message = "The following operation will onboard the device."
+        raise AdminError("Device already onboarded")
+
+    message = "The following operation will onboard the device."
     head([
         message,
         "Do you want to proceed? Yes/No",

--- a/middleware/ledger/hsm2dongle.py
+++ b/middleware/ledger/hsm2dongle.py
@@ -369,6 +369,9 @@ class HSM2DongleErrorResult(HSM2DongleBaseError):
     def error_code(self):
         return self.args[0]
 
+    def __str__(self):
+        return f"Dongle returned error code {hex(self.error_code)}"
+
 
 # Handles low-level communication with a powHSM dongle
 class HSM2Dongle:


### PR DESCRIPTION
- Preventing SEED and WIPE commands from executing if device is already onboarded
- Preventing onboarding tool from executing onboarding if device is already onboarded
- Added unit test cases for firmware and middleware changes
- Improving output for `HSM2DongleErrorResult` errors