### PR TITLE
Changed signapp usage

### DIFF
--- a/build-dist
+++ b/build-dist
@@ -56,7 +56,7 @@ cp $ROOT_DIR/middleware/bin/signapp.tgz $BIN_DIR
 echo
 
 computeHash() {
-    APP_HASH=$($ROOT_DIR/docker/mware/do-notty-nousb /hsm2 "python middleware/signapp.py hash -s $HEX_PATH" | \
+    APP_HASH=$($ROOT_DIR/docker/mware/do-notty-nousb /hsm2 "python middleware/signapp.py hash -a $HEX_PATH" | \
         grep "Computed hash:" | \
         sed "s/Computed hash: //g")
 
@@ -90,7 +90,7 @@ mv -f $ROOT_DIR/$CA_FILE $SCRIPTS_DIR/$CA_FILE
 
 SIGNER_AUTH_FILE="signer_auth.json"
 echo -e "\e[33mCreating empty signer authorization for upgrades...\e[0m"
-$ROOT_DIR/docker/mware/do-notty-nousb /hsm2 "python middleware/signapp.py message -s ledger/src/signer/bin/app.hex -i $UI_ITERATION -o $SIGNER_AUTH_FILE" > /dev/null
+$ROOT_DIR/docker/mware/do-notty-nousb /hsm2 "python middleware/signapp.py message -a ledger/src/signer/bin/app.hex -i $UI_ITERATION -o $SIGNER_AUTH_FILE" > /dev/null
 mv -f $ROOT_DIR/$SIGNER_AUTH_FILE $FIRMWARE_DIR/$SIGNER_AUTH_FILE
 
 echo

--- a/middleware/signapp.py
+++ b/middleware/signapp.py
@@ -52,10 +52,10 @@ def main():
     parser = ArgumentParser(description="powHSM Signer Authorization Generator")
     parser.add_argument("operation", choices=["hash", "message", "key", "eth", "manual"])
     parser.add_argument(
-        "-s",
-        "--signer",
-        dest="signer_path",
-        help="Signer path (used to compute the signer hash and authorization message).",
+        "-a",
+        "--app",
+        dest="app_path",
+        help="App path (used to compute the app hash and authorization message).",
     )
     parser.add_argument(
         "-i",
@@ -167,20 +167,20 @@ def main():
             signer_authorization = SignerAuthorization.from_jsonfile(options.output_path)
             signer_version = signer_authorization.signer_version
         else:
-            if options.signer_path is None:
-                raise AdminError("Must provide a signer path with '-s/--signer'")
+            if options.app_path is None:
+                raise AdminError("Must provide an app path with '-a/--app'")
 
             if options.operation != "hash" and options.iteration is None:
                 raise AdminError("Must provide a signer iteration with '-i/--iteration'")
 
             info("Computing hash...")
-            signer_hash = compute_app_hash(options.signer_path).hex()
+            app_hash = compute_app_hash(options.app_path).hex()
             if options.operation == "hash":
-                info(f"Computed hash: {signer_hash}")
+                info(f"Computed hash: {app_hash}")
                 sys.exit(0)
 
             info("Computing signer authorization message...")
-            signer_version = SignerVersion(signer_hash, options.iteration)
+            signer_version = SignerVersion(app_hash, options.iteration)
             signer_authorization = SignerAuthorization.for_signer_version(signer_version)
 
         if options.operation == "message":

--- a/middleware/tests/admin/test_signapp.py
+++ b/middleware/tests/admin/test_signapp.py
@@ -39,7 +39,7 @@ class TestSignAppHash(TestCase):
     def test_ok(self, info_mock, compute_app_hash_mock):
         compute_app_hash_mock.return_value = bytes.fromhex("aabbcc")
 
-        with patch("sys.argv", ["signapp.py", "hash", "-s", "a-path"]):
+        with patch("sys.argv", ["signapp.py", "hash", "-a", "a-path"]):
             with self.assertRaises(SystemExit) as exit:
                 main()
 
@@ -62,7 +62,7 @@ class TestSignAppMessage(TestCase):
         signer_version_mock.return_value = signer_version
         signer_version.get_authorization_msg.return_value = b"the-authorization-message"
 
-        with patch("sys.argv", ["signapp.py", "message", "-s", "a-path",
+        with patch("sys.argv", ["signapp.py", "message", "-a", "a-path",
                                 "-i", "an-iteration"]):
             with self.assertRaises(SystemExit) as exit:
                 main()
@@ -85,7 +85,7 @@ class TestSignAppMessage(TestCase):
         signer_authorization = Mock()
         signer_authorization_mock.for_signer_version.return_value = signer_authorization
 
-        with patch("sys.argv", ["signapp.py", "message", "-s", "a-path",
+        with patch("sys.argv", ["signapp.py", "message", "-a", "a-path",
                                 "-i", "an-iteration", "-o", "an-output-path"]):
             with self.assertRaises(SystemExit) as exit:
                 main()
@@ -117,7 +117,7 @@ class TestSignAppKey(TestCase):
         signer_authorization_mock.for_signer_version.return_value = signer_authorization
         isfile_mock.return_value = False
 
-        with patch("sys.argv", ["signapp.py", "key", "-s", "a-path",
+        with patch("sys.argv", ["signapp.py", "key", "-a", "a-path",
                                 "-i", "an-iteration", "-o", "an-output-path",
                                 "-k", "aa"*32]):
             with self.assertRaises(SystemExit) as exit:
@@ -200,7 +200,7 @@ class TestSignAppEth(TestCase):
             bytes.fromhex("bb"*32), sigencode=ecdsa.util.sigencode_der)
         get_eth_mock.return_value = eth_mock
         isfile_mock.return_value = False
-        with patch("sys.argv", ["signapp.py", "eth", "-s", "a-path",
+        with patch("sys.argv", ["signapp.py", "eth", "-a", "a-path",
                                 "-i", "an-iteration", "-o", "an-output-path"]):
             with self.assertRaises(SystemExit) as exit:
                 main()


### PR DESCRIPTION
In the past, we changed `siggnapp` usage to use `-s` for the signer firmware instead of `-a`. We are now changing this back to `-a` to keep it backward compatible with older versions of our tools.