### PR TITLE
Updating Github actions to use node16 versions

### DIFF
--- a/.github/workflows/lint-c.yml
+++ b/.github/workflows/lint-c.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build the ledger docker image
         run: docker/ledger/build

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build the middleware docker image
         run: docker/mware/build

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build the middleware docker image
         run: docker/mware/build
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout rsk-powhsm repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: rsk-powhsm
 
@@ -67,7 +67,7 @@ jobs:
           ledger/build/build-tcpsigner
 
       - name: Checkout hsm-integration-test repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: rootstock/hsm-integration-test
           ref: 4.0.0.plus


### PR DESCRIPTION
- Updating `actions/checkout` to `v3`