### PR TITLE
Updated base image for mware, tcpsigner-bundle and packer

### DIFF
--- a/docker/mware/Dockerfile
+++ b/docker/mware/Dockerfile
@@ -1,20 +1,20 @@
-FROM python:3.7.10-slim-stretch
+FROM python:3.7.16-slim-bullseye
 
 WORKDIR /hsm2
 
 RUN apt-get update && \
     apt-get install -y apt-utils vim && \
-    apt-get install -y build-essential=12.3 && \
+    apt-get install -y build-essential=12.9 && \
     apt-get install -y git
 
 # Python package prerequisites
 RUN apt-get install -y \
-    libsecp256k1-dev=0.1~20161228-1 \
-    python3-pkgconfig=1.2.2-1 \
-    libusb-1.0-0-dev=2:1.0.21-1 \
-    libudev-dev=232-25+deb9u12 \
-    libffi-dev=3.2.1-6 #\
-    libjpeg-dev=1:1.5.1-2+deb9u2
+    libsecp256k1-dev=0.1~20210108-1 \
+    python3-pkgconfig=1.5.1-3 \
+    libusb-1.0-0-dev=2:1.0.24-3 \
+    libudev-dev=247.3-7+deb11u2 \
+    libffi-dev=3.3-6 #\
+    libjpeg-dev=1:2.0.6-4
 
 COPY requirements.txt /hsm2/requirements.txt
 RUN pip install -r requirements.txt --require-hashes

--- a/docker/packer/Dockerfile
+++ b/docker/packer/Dockerfile
@@ -1,6 +1,6 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 WORKDIR /hsm2
 
 RUN apt-get update && \
-    apt-get install -y apt-utils binutils=2.31.1-16 vim
+    apt-get install -y apt-utils binutils=2.35.2-2 vim

--- a/utils/tcpsigner-bundle/dist/Dockerfile
+++ b/utils/tcpsigner-bundle/dist/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 
 RUN apt-get update && \
     apt-get install -y procps libsecp256k1-dev


### PR DESCRIPTION
The previously used base image, debian stretch, has reached end of life. This was causing build issues both locally and on the CI. This commit updates the base image to debian bullseye, which is the current stable release with LTS. This also updates some package versions to the ones currently supported.