### PR TITLE
Updated base image for powHSM distribution

### DIFF
--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 RUN apt-get update && \
     apt-get install -y gnupg2


### PR DESCRIPTION
Following the middleware, tcpsigner-bundle and packer docker image updates we also need to update the base image for the powHSM distribution in order to be able to build and run the generated distributions.