### PR TITLE
Periodic unit and integration tests workflow run (only master)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,9 @@
 name: Run tests
 
-on: [push]
+on:
+  push:
+  schedule:
+    - cron: "17 6 * * *"
 
 jobs:
   run-unit-tests:


### PR DESCRIPTION
Scheduled to run every 24hs.

Unsuccessfully attempted to also add running the tests on the `develop-2.3` branch (which points to the latest `2.3` release). More time needs to be allocated for this since multiple workflows on multiple branches need to be updated in order for this to work (since workflow scheduling only works for `master` and hence specific artifacts have to be implemented to be able to run on a different branch).