### PR TITLE
Adds "screen saver" mode to signer app

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Ledger UI's unit tests
         run: firmware/src/ledger/ui/test/run-all.sh
 
+      - name: Ledger Signer's unit tests
+        run: firmware/src/ledger/signer/test/run-all.sh
+
   run-integration-tests:
     name: Integration tests
     runs-on: ubuntu-20.04

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -24,6 +24,7 @@ Unless otherwise stated, only x86 platforms are supported for building this proj
 ~/repo> middleware/test-all # Middleware unit tests
 ~/repo> firmware/test/test-all # Firmware tests
 ~/repo> firmware/src/ledger/ui/test/run-all.sh # Ledger UI application unit tests
+~/repo> firmware/src/ledger/signer/test/run-all.sh # Ledger Signer application unit tests
 ~/repo> firmware/src/common/test/run-all.sh # Common code unit tests
 ~/repo> firmware/src/powhsm/test/run-all.sh # powHSM logic unit tests
 ~/repo> firmware/src/hal/test/run-all.sh # HAL unit tests

--- a/firmware/coverage/gen-coverage
+++ b/firmware/coverage/gen-coverage
@@ -13,6 +13,7 @@ if [[ $1 == "exec" ]]; then
     COVERAGE=y $REPOROOT/firmware/src/common/test/run-all.sh
     COVERAGE=y $REPOROOT/firmware/src/powhsm/test/run-all.sh
     COVERAGE=y $REPOROOT/firmware/src/ledger/ui/test/run-all.sh
+    COVERAGE=y $REPOROOT/firmware/src/ledger/signer/test/run-all.sh
     COVERAGE=y $REPOROOT/firmware/src/tcpsigner/test/run-all.sh
 
     # Run tcpsigner test suite

--- a/firmware/src/ledger/signer/src/main.c
+++ b/firmware/src/ledger/signer/src/main.c
@@ -43,83 +43,20 @@
 #include "os_io_seproxyhal.h"
 
 #include "hsm.h"
+#include "signer_ux.h"
 
 // HAL includes
 #include "hal/communication.h"
 
-unsigned char G_io_seproxyhal_spi_buffer[IO_SEPROXYHAL_BUFFER_SIZE_B];
-
-// UI currently displayed
-enum UI_STATE { UI_INFO, UI_SCREENSAVER };
-enum UI_STATE uiState;
-ux_state_t ux;
-
-#define SCREEN_SAVER_TIMEOUT_MS 30000
 // The interval between two subsequent ticker events in milliseconds. This is
 // assumed to be 100ms according to the nanos-secure-sdk documentation.
 #define TICKER_INTERVAL_MS 100
-// Time spent in idle state. This timer is reset when a button is pressed.
-static unsigned int G_idle_time_ms;
+// The time in milliseconds after which the screen saver is displayed if no
+// button is pressed
+#define SCREEN_SAVER_TIMEOUT_MS 30000
 
-// clang-format off
-static const bagl_element_t bagl_ui_info_nanos[] = {
-    {
-        {BAGL_RECTANGLE, 0x00, 0, 0, 128, 32, 0, 0, BAGL_FILL, 0x000000,
-         0xFFFFFF, 0, 0},
-        NULL,
-        0,
-        0,
-        0,
-        NULL,
-        NULL,
-        NULL,
-    },
-    {
-        {BAGL_LABELINE, 0x02, 0, 12, 128, 11, 0, 0, 0, 0xFFFFFF, 0x000000,
-         BAGL_FONT_OPEN_SANS_REGULAR_11px | BAGL_FONT_ALIGNMENT_CENTER, 0},
-        "Signer running...",
-        0,
-        0,
-        0,
-        NULL,
-        NULL,
-        NULL,
-    }
-};
-
-static const bagl_element_t bagl_ui_screensaver_nanos[] = {
-    {
-        {BAGL_RECTANGLE, 0x00, 0, 0, 128, 32, 0, 0, BAGL_FILL, 0x000000,
-         0x000000, 0, 0},
-        NULL,
-        0,
-        0,
-        0,
-        NULL,
-        NULL,
-        NULL,
-    },
-};
-// clang-format on
-
-static unsigned int bagl_ui_info_nanos_button(
-    unsigned int button_mask, unsigned int button_mask_counter) {
-    switch (button_mask) {
-    case BUTTON_EVT_RELEASED | BUTTON_LEFT:
-    case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
-        //     We removed this function, but leave it in src in case its needed
-        //     for debug. io_seproxyhal_touch_exit(NULL);
-        break;
-    }
-
-    return 0;
-}
-
-static unsigned int bagl_ui_screensaver_nanos_button(
-    unsigned int button_mask, unsigned int button_mask_counter) {
-    // no-op - button presses are handled directly in the event loop
-    return 0;
-}
+unsigned char G_io_seproxyhal_spi_buffer[IO_SEPROXYHAL_BUFFER_SIZE_B];
+ux_state_t ux;
 
 unsigned short io_exchange_al(unsigned char channel, unsigned short tx_len) {
     switch (channel & ~(IO_FLAGS)) {
@@ -151,46 +88,6 @@ void io_seproxyhal_display(const bagl_element_t *element) {
     io_seproxyhal_display_default((bagl_element_t *)element);
 }
 
-static void ui_info(void) {
-    uiState = UI_INFO;
-    UX_DISPLAY(bagl_ui_info_nanos, NULL);
-}
-
-static void ui_screensaver(void) {
-    uiState = UI_SCREENSAVER;
-    UX_DISPLAY(bagl_ui_screensaver_nanos, NULL);
-}
-
-static void handle_button_press(void) {
-    G_idle_time_ms = 0;
-}
-
-static void handle_ticker_event(void) {
-    unsigned int last_idle_time_ms = G_idle_time_ms;
-    G_idle_time_ms += TICKER_INTERVAL_MS;
-    // Handle overflow
-    if (G_idle_time_ms < last_idle_time_ms) {
-        G_idle_time_ms = last_idle_time_ms;
-    }
-}
-
-static void handle_ui_state(void) {
-    switch (uiState) {
-    case UI_INFO:
-        if (G_idle_time_ms >= SCREEN_SAVER_TIMEOUT_MS) {
-            ui_screensaver();
-        }
-        break;
-    case UI_SCREENSAVER:
-        if (G_idle_time_ms < SCREEN_SAVER_TIMEOUT_MS) {
-            ui_info();
-        }
-        break;
-    default:
-        break;
-    }
-}
-
 unsigned char io_event(unsigned char channel) {
     // nothing done with the event, throw an error on the transport layer if
     // needed
@@ -203,7 +100,7 @@ unsigned char io_event(unsigned char channel) {
 
     case SEPROXYHAL_TAG_BUTTON_PUSH_EVENT: // for Nano S
         UX_BUTTON_PUSH_EVENT(G_io_seproxyhal_spi_buffer);
-        handle_button_press();
+        signer_ux_handle_button_press();
         break;
 
     case SEPROXYHAL_TAG_DISPLAY_PROCESSED_EVENT:
@@ -214,9 +111,8 @@ unsigned char io_event(unsigned char channel) {
             // defaulty retrig very soon (will be overriden during
             // stepper_prepro)
             UX_CALLBACK_SET_INTERVAL(500);
-            handle_ui_state();
         });
-        handle_ticker_event();
+        signer_ux_handle_ticker_event(TICKER_INTERVAL_MS);
         break;
 
     // unknown events are acknowledged
@@ -286,8 +182,7 @@ __attribute__((section(".boot"))) int main(int argc, char **argv) {
             USB_power(0);
             USB_power(1);
 
-            ui_info();
-            G_idle_time_ms = 0;
+            signer_ux_init(SCREEN_SAVER_TIMEOUT_MS);
 
             // next timer callback in 500 ms
             UX_CALLBACK_SET_INTERVAL(500);

--- a/firmware/src/ledger/signer/src/main.c
+++ b/firmware/src/ledger/signer/src/main.c
@@ -58,8 +58,6 @@ ux_state_t ux;
 // Time spent in idle state. This timer is reset when a button is pressed.
 static unsigned int G_idle_time_ms;
 
-static void ui_idle(void);
-
 // clang-format off
 static const bagl_element_t bagl_ui_idle_nanos[] = {
     {

--- a/firmware/src/ledger/signer/src/main.c
+++ b/firmware/src/ledger/signer/src/main.c
@@ -55,6 +55,9 @@ enum UI_STATE uiState;
 ux_state_t ux;
 
 #define SCREEN_SAVER_TIMEOUT_MS 30000
+// The interval between two subsequent ticker events in milliseconds. This is
+// assumed to be 100ms according to the nanos-secure-sdk documentation.
+#define TICKER_INTERVAL_MS 100
 // Time spent in idle state. This timer is reset when a button is pressed.
 static unsigned int G_idle_time_ms;
 
@@ -164,7 +167,7 @@ static void handle_button_press(void) {
 
 static void handle_ticker_event(void) {
     unsigned int last_idle_time_ms = G_idle_time_ms;
-    G_idle_time_ms += 100;
+    G_idle_time_ms += TICKER_INTERVAL_MS;
     // Handle overflow
     if (G_idle_time_ms < last_idle_time_ms) {
         G_idle_time_ms = last_idle_time_ms;

--- a/firmware/src/ledger/signer/src/main.c
+++ b/firmware/src/ledger/signer/src/main.c
@@ -50,7 +50,7 @@
 unsigned char G_io_seproxyhal_spi_buffer[IO_SEPROXYHAL_BUFFER_SIZE_B];
 
 // UI currently displayed
-enum UI_STATE { UI_IDLE, UI_SCREENSAVER };
+enum UI_STATE { UI_INFO, UI_SCREENSAVER };
 enum UI_STATE uiState;
 ux_state_t ux;
 
@@ -62,7 +62,7 @@ ux_state_t ux;
 static unsigned int G_idle_time_ms;
 
 // clang-format off
-static const bagl_element_t bagl_ui_idle_nanos[] = {
+static const bagl_element_t bagl_ui_info_nanos[] = {
     {
         {BAGL_RECTANGLE, 0x00, 0, 0, 128, 32, 0, 0, BAGL_FILL, 0x000000,
          0xFFFFFF, 0, 0},
@@ -102,7 +102,7 @@ static const bagl_element_t bagl_ui_screensaver_nanos[] = {
 };
 // clang-format on
 
-static unsigned int bagl_ui_idle_nanos_button(
+static unsigned int bagl_ui_info_nanos_button(
     unsigned int button_mask, unsigned int button_mask_counter) {
     switch (button_mask) {
     case BUTTON_EVT_RELEASED | BUTTON_LEFT:
@@ -151,9 +151,9 @@ void io_seproxyhal_display(const bagl_element_t *element) {
     io_seproxyhal_display_default((bagl_element_t *)element);
 }
 
-static void ui_idle(void) {
-    uiState = UI_IDLE;
-    UX_DISPLAY(bagl_ui_idle_nanos, NULL);
+static void ui_info(void) {
+    uiState = UI_INFO;
+    UX_DISPLAY(bagl_ui_info_nanos, NULL);
 }
 
 static void ui_screensaver(void) {
@@ -176,14 +176,14 @@ static void handle_ticker_event(void) {
 
 static void handle_ui_state(void) {
     switch (uiState) {
-    case UI_IDLE:
+    case UI_INFO:
         if (G_idle_time_ms >= SCREEN_SAVER_TIMEOUT_MS) {
             ui_screensaver();
         }
         break;
     case UI_SCREENSAVER:
         if (G_idle_time_ms < SCREEN_SAVER_TIMEOUT_MS) {
-            ui_idle();
+            ui_info();
         }
         break;
     default:
@@ -286,7 +286,7 @@ __attribute__((section(".boot"))) int main(int argc, char **argv) {
             USB_power(0);
             USB_power(1);
 
-            ui_idle();
+            ui_info();
             G_idle_time_ms = 0;
 
             // next timer callback in 500 ms

--- a/firmware/src/ledger/signer/src/signer_ux.c
+++ b/firmware/src/ledger/signer/src/signer_ux.c
@@ -1,0 +1,77 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 RSK Labs Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "signer_ux.h"
+
+// UI currently displayed
+enum UI_STATE { UI_INFO, UI_SCREENSAVER };
+enum UI_STATE G_ui_state;
+// Time spent since the last button press
+static unsigned int G_idle_time_ms;
+// The time in milliseconds after which the screen saver is displayed if no
+// button is pressed
+static unsigned int G_screensaver_timeout_ms;
+
+// Local functions
+static void signer_ux_update(void) {
+    switch (G_ui_state) {
+    case UI_INFO:
+        if (G_idle_time_ms >= G_screensaver_timeout_ms) {
+            G_ui_state = UI_SCREENSAVER;
+            signer_ux_screensaver();
+        }
+        break;
+    case UI_SCREENSAVER:
+        if (G_idle_time_ms < G_screensaver_timeout_ms) {
+            G_ui_state = UI_INFO;
+            signer_ux_info();
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+// Public interface
+void signer_ux_init(unsigned int screensaver_timeout_ms) {
+    G_idle_time_ms = 0;
+    G_ui_state = UI_INFO;
+    G_screensaver_timeout_ms = screensaver_timeout_ms;
+    signer_ux_info();
+}
+
+void signer_ux_handle_button_press(void) {
+    G_idle_time_ms = 0;
+    signer_ux_update();
+}
+
+void signer_ux_handle_ticker_event(unsigned int interval_ms) {
+    unsigned int last_idle_time_ms = G_idle_time_ms;
+    G_idle_time_ms += interval_ms;
+    // Handle overflow
+    if (G_idle_time_ms < last_idle_time_ms) {
+        G_idle_time_ms = last_idle_time_ms;
+    }
+    signer_ux_update();
+}

--- a/firmware/src/ledger/signer/src/signer_ux.h
+++ b/firmware/src/ledger/signer/src/signer_ux.h
@@ -1,0 +1,55 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 RSK Labs Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef __SIGNER_UX_H
+#define __SIGNER_UX_H
+
+/*
+ * Initialize the UX state.
+ *
+ * @arg[in] screensaver_timeout_ms The time after which the screen saver is
+ *                                 displayed if no button is pressed
+ */
+void signer_ux_init(unsigned int screensaver_timeout_ms);
+
+/*
+ * Handle a button press event.
+ *
+ * This function should be called whenever a button is pressed.
+ */
+void signer_ux_handle_button_press(void);
+/*
+ * Handles a ticker event.
+ *
+ * Increments the internal timer and updates the UI state if necessary.
+ *
+ * @arg[in] interval_ms Time spent since last ticker event
+ */
+void signer_ux_handle_ticker_event(unsigned int interval_ms);
+
+// all screens
+void signer_ux_info(void);
+void signer_ux_screensaver(void);
+
+#endif // __SIGNER_UX_H

--- a/firmware/src/ledger/signer/src/signer_ux_info.c
+++ b/firmware/src/ledger/signer/src/signer_ux_info.c
@@ -1,0 +1,63 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 RSK Labs Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "os_io_seproxyhal.h"
+#include "signer_ux.h"
+
+// clang-format off
+static const bagl_element_t bagl_ui_info_nanos[] = {
+    {
+        {BAGL_RECTANGLE, 0x00, 0, 0, 128, 32, 0, 0, BAGL_FILL, 0x000000,
+         0xFFFFFF, 0, 0},
+        NULL,
+        0,
+        0,
+        0,
+        NULL,
+        NULL,
+        NULL,
+    },
+    {
+        {BAGL_LABELINE, 0x02, 0, 12, 128, 11, 0, 0, 0, 0xFFFFFF, 0x000000,
+         BAGL_FONT_OPEN_SANS_REGULAR_11px | BAGL_FONT_ALIGNMENT_CENTER, 0},
+        "Signer running...",
+        0,
+        0,
+        0,
+        NULL,
+        NULL,
+        NULL,
+    }
+};
+// clang-format on
+
+static unsigned int bagl_ui_info_nanos_button(
+    unsigned int button_mask, unsigned int button_mask_counter) {
+    // no-op - button presses are handled directly in the event loop
+    return 0;
+}
+
+void signer_ux_info(void) {
+    UX_DISPLAY(bagl_ui_info_nanos, NULL);
+}

--- a/firmware/src/ledger/signer/src/signer_ux_screensaver.c
+++ b/firmware/src/ledger/signer/src/signer_ux_screensaver.c
@@ -1,0 +1,52 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 RSK Labs Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "os_io_seproxyhal.h"
+#include "signer_ux.h"
+
+// clang-format off
+static const bagl_element_t bagl_ui_screensaver_nanos[] = {
+    {
+        {BAGL_RECTANGLE, 0x00, 0, 0, 128, 32, 0, 0, BAGL_FILL, 0x000000,
+         0x000000, 0, 0},
+        NULL,
+        0,
+        0,
+        0,
+        NULL,
+        NULL,
+        NULL,
+    },
+};
+// clang-format on
+
+static unsigned int bagl_ui_screensaver_nanos_button(
+    unsigned int button_mask, unsigned int button_mask_counter) {
+    // no-op - button presses are handled directly in the event loop
+    return 0;
+}
+
+void signer_ux_screensaver(void) {
+    UX_DISPLAY(bagl_ui_screensaver_nanos, NULL);
+}

--- a/firmware/src/ledger/signer/src/signer_ux_screensaver.c
+++ b/firmware/src/ledger/signer/src/signer_ux_screensaver.c
@@ -22,6 +22,7 @@
  * IN THE SOFTWARE.
  */
 
+#include <stddef.h>
 #include "os_io_seproxyhal.h"
 #include "signer_ux.h"
 

--- a/firmware/src/ledger/signer/test/common.mk
+++ b/firmware/src/ledger/signer/test/common.mk
@@ -1,0 +1,31 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021 RSK Labs Ltd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+INCDIR = ../../../include
+SRCDIR = ../../src
+CFLAGS  = -iquote $(INCDIR) -iquote $(SRCDIR)
+
+include ../../../../../coverage/coverage.mk
+
+CFLAGS += $(COVFLAGS)
+
+VPATH += $(SRCDIR):$(INCDIR)

--- a/firmware/src/ledger/signer/test/mock/common.mk
+++ b/firmware/src/ledger/signer/test/mock/common.mk
@@ -20,12 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-INCDIR = ../../../include
 SRCDIR = ../../src
-CFLAGS  = -iquote $(INCDIR) -iquote $(SRCDIR)
+COMMONDIR = ../../../../common/src
+MOCKDIR = ../mock
+THISMOCKDIR = ./mock
+CFLAGS  = -iquote $(THISMOCKDIR) -iquote $(MOCKDIR)
+CFLAGS += -iquote $(SRCDIR)
 
 include ../../../../../coverage/coverage.mk
-
-CFLAGS += $(COVFLAGS)
-
-VPATH += $(SRCDIR):$(INCDIR)

--- a/firmware/src/ledger/signer/test/mock/mock.h
+++ b/firmware/src/ledger/signer/test/mock/mock.h
@@ -22,43 +22,47 @@
  * IN THE SOFTWARE.
  */
 
-#include <stddef.h>
-#include "os_io_seproxyhal.h"
-#include "signer_ux.h"
+#ifndef __SIGNER_MOCK_H
+#define __SIGNER_MOCK_H
 
-// clang-format off
-static const bagl_element_t bagl_ui_info_nanos[] = {
-    {
-        {BAGL_RECTANGLE, 0x00, 0, 0, 128, 32, 0, 0, BAGL_FILL, 0x000000,
-         0xFFFFFF, 0, 0},
-        NULL,
-        0,
-        0,
-        0,
-        NULL,
-        NULL,
-        NULL,
-    },
-    {
-        {BAGL_LABELINE, 0x02, 0, 12, 128, 11, 0, 0, 0, 0xFFFFFF, 0x000000,
-         BAGL_FONT_OPEN_SANS_REGULAR_11px | BAGL_FONT_ALIGNMENT_CENTER, 0},
-        "Signer running...",
-        0,
-        0,
-        0,
-        NULL,
-        NULL,
-        NULL,
-    }
-};
-// clang-format on
+// Nano S SDK constants used by the signer ux components
+#define BAGL_FILL 1
+#define BAGL_RECTANGLE 3
+#define BAGL_LABELINE 7
+#define BAGL_FONT_OPEN_SANS_REGULAR_11px 10
+#define BAGL_FONT_ALIGNMENT_CENTER 0x8000
 
-static unsigned int bagl_ui_info_nanos_button(
-    unsigned int button_mask, unsigned int button_mask_counter) {
-    // no-op - button presses are handled directly in the event loop
-    return 0;
-}
+// Nano S SDK types used by the signer ux components
+typedef struct {
+    unsigned int type;
+    unsigned char userid;
+    short x;
+    short y;
+    unsigned short width;
+    unsigned short height;
+    unsigned char stroke;
+    unsigned char radius;
+    unsigned char fill;
+    unsigned int fgcolor;
+    unsigned int bgcolor;
+    unsigned short font_id;
+    unsigned char icon_id;
+} mock_signer_ux_component_t;
 
-void signer_ux_info(void) {
-    UX_DISPLAY(bagl_ui_info_nanos, NULL);
-}
+typedef struct {
+    mock_signer_ux_component_t component;
+    const char *text;
+    unsigned char touch_area_brim;
+    int overfgcolor;
+    int overbgcolor;
+    const void *tap;
+    const void *out;
+    const void *over;
+} mock_signer_ux_element_t;
+
+typedef mock_signer_ux_element_t bagl_element_t;
+
+// Nano S SDK functions and macros used by the signer ux components
+void UX_DISPLAY(const mock_signer_ux_element_t *elements_array, void *callback);
+
+#endif // __SIGNER_MOCK_H

--- a/firmware/src/ledger/signer/test/mock/os_io_seproxyhal.h
+++ b/firmware/src/ledger/signer/test/mock/os_io_seproxyhal.h
@@ -1,0 +1,1 @@
+../../../ui/test/mock/os_io_seproxyhal.h

--- a/firmware/src/ledger/signer/test/run-all.sh
+++ b/firmware/src/ledger/signer/test/run-all.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+BASEDIR=$(dirname $0)
+TESTDIRS="signer_ux"
+TESTDIRS=${1:-"$TESTDIRS"}
+
+for d in $TESTDIRS; do
+    echo "******************************"
+    echo "Testing $d..."
+    echo "******************************"
+    cd "$BASEDIR/$d"
+    make clean test || exit $?
+    cd - > /dev/null
+done

--- a/firmware/src/ledger/signer/test/signer_ux/Makefile
+++ b/firmware/src/ledger/signer/test/signer_ux/Makefile
@@ -1,0 +1,45 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021 RSK Labs Ltd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+PROG = test.out
+OBJS = signer_ux.o test_signer_ux.o
+
+include ../common.mk
+
+all: $(PROG)
+
+$(PROG): $(OBJS)
+	$(CC) $(COVFLAGS) -o $@ $^ -g
+
+test_signer_ux.o: test_signer_ux.c
+	$(CC) $(CFLAGS) -c -o $@ $^
+
+signer_ux.o: $(SRCDIR)/signer_ux.c
+	$(CC) $(CFLAGS) -c -o $@ $^
+
+.PHONY: clean test
+
+clean:
+	rm -f $(PROG) *.o $(COVFILES)
+
+test: all
+	./$(PROG)

--- a/firmware/src/ledger/signer/test/signer_ux/Makefile
+++ b/firmware/src/ledger/signer/test/signer_ux/Makefile
@@ -20,10 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-PROG = test.out
-OBJS = signer_ux.o test_signer_ux.o
+include ../mock/common.mk
 
-include ../common.mk
+PROG = test.out
+OBJS = signer_ux.o signer_ux_info.o signer_ux_screensaver.o test_signer_ux.o
 
 all: $(PROG)
 
@@ -33,8 +33,8 @@ $(PROG): $(OBJS)
 test_signer_ux.o: test_signer_ux.c
 	$(CC) $(CFLAGS) -c -o $@ $^
 
-signer_ux.o: $(SRCDIR)/signer_ux.c
-	$(CC) $(CFLAGS) -c -o $@ $^
+%.o: $(SRCDIR)/%.c
+	$(CC) $(CFLAGS) $(COVFLAGS) -c -o $@ $^
 
 .PHONY: clean test
 

--- a/firmware/src/ledger/signer/test/signer_ux/test_signer_ux.c
+++ b/firmware/src/ledger/signer/test/signer_ux/test_signer_ux.c
@@ -1,0 +1,113 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 RSK Labs Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include "signer_ux.h"
+
+static unsigned int G_mock_idle_time_ms;
+static unsigned int G_mock_screensaver_timeout_ms;
+enum mock_ui_state { MOCK_UI_INFO, MOCK_UI_SCREENSAVER, MOCK_UI_INVALID };
+enum mock_ui_state G_mock_ui_state;
+
+// Helper functions
+static unsigned int max(unsigned int a, unsigned int b) {
+    return a > b ? a : b;
+}
+
+// Mock function calls
+void signer_ux_info(void) {
+    G_mock_ui_state = MOCK_UI_INFO;
+}
+
+void signer_ux_screensaver(void) {
+    G_mock_ui_state = MOCK_UI_SCREENSAVER;
+}
+
+// Test cases
+void setup() {
+    G_mock_idle_time_ms = 0;
+    G_mock_screensaver_timeout_ms = 30000;
+    G_mock_ui_state = MOCK_UI_INVALID;
+    signer_ux_init(G_mock_screensaver_timeout_ms);
+}
+
+void test_init() {
+    printf("Test init...\n");
+    setup();
+    assert(MOCK_UI_INFO == G_mock_ui_state);
+}
+
+void test_ui_info_ui_screensaver_transition() {
+    printf("Test transition from UI_INFO to UI_SCREENSAVER...\n");
+    setup();
+    signer_ux_handle_ticker_event(G_mock_screensaver_timeout_ms - 1);
+    assert(MOCK_UI_INFO == G_mock_ui_state);
+    signer_ux_handle_ticker_event(1);
+    assert(MOCK_UI_SCREENSAVER == G_mock_ui_state);
+}
+
+void test_ui_screensaver_ui_info_transition() {
+    printf("Test transition from UI_SCREENSAVER to UI_INFO...\n");
+    setup();
+    signer_ux_handle_ticker_event(G_mock_screensaver_timeout_ms);
+    assert(MOCK_UI_SCREENSAVER == G_mock_ui_state);
+    signer_ux_handle_button_press();
+    assert(MOCK_UI_INFO == G_mock_ui_state);
+}
+
+void test_multiple_button_presses() {
+    printf("Test multiple button presses...\n");
+    setup();
+    for (int i = 0; i < 100; ++i) {
+        signer_ux_handle_ticker_event(G_mock_screensaver_timeout_ms - 1);
+        assert(MOCK_UI_INFO == G_mock_ui_state);
+        signer_ux_handle_button_press();
+        assert(MOCK_UI_INFO == G_mock_ui_state);
+    }
+}
+
+void test_timer_overflow() {
+    printf("Test timer overflow protection...\n");
+    setup();
+    unsigned int mock_tick_ms = 100;
+    signer_ux_handle_ticker_event(__UINT32_MAX__ - 100);
+    assert(MOCK_UI_SCREENSAVER == G_mock_ui_state);
+    for (int i = 0; i < 1000; i += mock_tick_ms) {
+        signer_ux_handle_ticker_event(mock_tick_ms);
+        assert(MOCK_UI_SCREENSAVER == G_mock_ui_state);
+    }
+    signer_ux_handle_button_press();
+    assert(MOCK_UI_INFO == G_mock_ui_state);
+}
+
+int main() {
+    test_init();
+    test_ui_info_ui_screensaver_transition();
+    test_ui_screensaver_ui_info_transition();
+    test_multiple_button_presses();
+    test_timer_overflow();
+
+    return 0;
+}


### PR DESCRIPTION

The screen saver screen is just a completely black screen with no active pixels. This
PR introduces the logic to switch to this "screen saver" screen after 30 seconds
of inactivity in the `signer` app. When any of the physical buttons is pressed, the usual
`Signer running...` screen is presented again.

Also, I took the chance to remove some unused states and their corresponding logic, since they were not being used.