### PR TITLE
Fix verify_attestation.py to accept distinct versions for UI and Signer

### DIFF
--- a/middleware/tests/admin/test_verify_attestation.py
+++ b/middleware/tests/admin/test_verify_attestation.py
@@ -27,8 +27,8 @@ from admin.misc import AdminError
 from admin.pubkeys import PATHS
 from admin.verify_attestation import (
     do_verify_attestation,
-    validate_ui_message_header,
-    validate_signer_message_header
+    match_ui_message_header,
+    match_signer_message_header
 )
 import ecdsa
 import hashlib
@@ -285,7 +285,7 @@ class TestVerifyAttestation(TestCase):
         self.assertEqual(("Invalid Signer attestation: error validating 'signer'"),
                          str(e.exception))
 
-    def test_validate_ui_message_header_valid_header(self, _):
+    def test_match_ui_message_header_valid_header(self, _):
         valid_headers = [
             UI_HEADER,
             b"HSM:UI:5.0",
@@ -294,9 +294,9 @@ class TestVerifyAttestation(TestCase):
         ]
         for header in valid_headers:
             ui_message = header + self.ui_msg[len(UI_HEADER):]
-            self.assertTrue(validate_ui_message_header(ui_message))
+            self.assertTrue(match_ui_message_header(ui_message))
 
-    def test_validate_ui_message_header_invalid_header(self, _):
+    def test_match_ui_message_header_invalid_header(self, _):
         invalid_headers = [
             SIGNER_HEADER,
             b"HSM:UI:4.0",
@@ -304,9 +304,9 @@ class TestVerifyAttestation(TestCase):
         ]
         for header in invalid_headers:
             ui_message = header + self.ui_msg[len(UI_HEADER):]
-            self.assertFalse(validate_ui_message_header(ui_message))
+            self.assertFalse(match_ui_message_header(ui_message))
 
-    def test_validate_signer_message_header_valid_header(self, _):
+    def test_match_signer_message_header_valid_header(self, _):
         valid_headers = [
             SIGNER_HEADER,
             b"HSM:SIGNER:5.0",
@@ -315,9 +315,9 @@ class TestVerifyAttestation(TestCase):
         ]
         for header in valid_headers:
             signer_message = header + self.signer_msg[len(SIGNER_HEADER):]
-            self.assertTrue(validate_signer_message_header(signer_message))
+            self.assertTrue(match_signer_message_header(signer_message))
 
-    def test_validate_signer_message_header_invalid_header(self, _):
+    def test_match_signer_message_header_invalid_header(self, _):
         invalid_headers = [
             UI_HEADER,
             b"HSM:SIGNER:4.0",
@@ -325,4 +325,4 @@ class TestVerifyAttestation(TestCase):
         ]
         for header in invalid_headers:
             signer_message = header + self.signer_msg[len(SIGNER_HEADER):]
-            self.assertFalse(validate_signer_message_header(signer_message))
+            self.assertFalse(match_signer_message_header(signer_message))

--- a/middleware/tests/admin/test_verify_attestation.py
+++ b/middleware/tests/admin/test_verify_attestation.py
@@ -25,7 +25,11 @@ from unittest import TestCase
 from unittest.mock import Mock, call, patch, mock_open
 from admin.misc import AdminError
 from admin.pubkeys import PATHS
-from admin.verify_attestation import do_verify_attestation
+from admin.verify_attestation import (
+    do_verify_attestation,
+    validate_ui_message_header,
+    validate_signer_message_header
+)
 import ecdsa
 import hashlib
 import logging
@@ -33,6 +37,8 @@ import logging
 logging.disable(logging.CRITICAL)
 
 EXPECTED_UI_DERIVATION_PATH = "m/44'/0'/0'/0/0"
+SIGNER_HEADER = b"HSM:SIGNER:5.1"
+UI_HEADER = b"HSM:UI:5.1"
 
 
 @patch("sys.stdout.write")
@@ -65,14 +71,14 @@ class TestVerifyAttestation(TestCase):
             )
         self.pubkeys_hash = pubkeys_hash.digest()
 
-        self.ui_msg = b"HSM:UI:5.1" + \
+        self.ui_msg = UI_HEADER + \
             bytes.fromhex("aa"*32) + \
             bytes.fromhex("bb"*33) + \
             bytes.fromhex("cc"*32) + \
             bytes.fromhex("0123")
         self.ui_hash = bytes.fromhex("ee" * 32)
 
-        self.signer_msg = b"HSM:SIGNER:5.1" + \
+        self.signer_msg = SIGNER_HEADER + \
             bytes.fromhex(self.pubkeys_hash.hex())
         self.signer_hash = bytes.fromhex("ff" * 32)
 
@@ -278,3 +284,45 @@ class TestVerifyAttestation(TestCase):
         self.assertEqual([call(self.pubkeys_path, 'r')], file_mock.call_args_list)
         self.assertEqual(("Invalid Signer attestation: error validating 'signer'"),
                          str(e.exception))
+
+    def test_validate_ui_message_header_valid_header(self, _):
+        valid_headers = [
+            UI_HEADER,
+            b"HSM:UI:5.0",
+            b"HSM:UI:5.5",
+            b"HSM:UI:5.9",
+        ]
+        for header in valid_headers:
+            ui_message = header + self.ui_msg[len(UI_HEADER):]
+            self.assertTrue(validate_ui_message_header(ui_message))
+
+    def test_validate_ui_message_header_invalid_header(self, _):
+        invalid_headers = [
+            SIGNER_HEADER,
+            b"HSM:UI:4.0",
+            b"HSM:UI:5.X",
+        ]
+        for header in invalid_headers:
+            ui_message = header + self.ui_msg[len(UI_HEADER):]
+            self.assertFalse(validate_ui_message_header(ui_message))
+
+    def test_validate_signer_message_header_valid_header(self, _):
+        valid_headers = [
+            SIGNER_HEADER,
+            b"HSM:SIGNER:5.0",
+            b"HSM:SIGNER:5.5",
+            b"HSM:SIGNER:5.9",
+        ]
+        for header in valid_headers:
+            signer_message = header + self.signer_msg[len(SIGNER_HEADER):]
+            self.assertTrue(validate_signer_message_header(signer_message))
+
+    def test_validate_signer_message_header_invalid_header(self, _):
+        invalid_headers = [
+            UI_HEADER,
+            b"HSM:SIGNER:4.0",
+            b"HSM:SIGNER:5.X",
+        ]
+        for header in invalid_headers:
+            signer_message = header + self.signer_msg[len(SIGNER_HEADER):]
+            self.assertFalse(validate_signer_message_header(signer_message))

--- a/middleware/tests/admin/test_verify_attestation.py
+++ b/middleware/tests/admin/test_verify_attestation.py
@@ -108,6 +108,7 @@ class TestVerifyAttestation(TestCase):
                 f"Authorized signer hash: {'cc'*32}",
                 "Authorized signer iteration: 291",
                 f"Installed UI hash: {'ee'*32}",
+                "Installed UI version: 5.1",
             ],
             fill="-",
         )
@@ -118,6 +119,7 @@ class TestVerifyAttestation(TestCase):
                 "",
                 f"Hash: {self.pubkeys_hash.hex()}",
                 f"Installed Signer hash: {'ff'*32}",
+                "Installed Signer version: 5.1",
             ],
             fill="-",
         )


### PR DESCRIPTION
- Version MINOR is now allowed to be distinct between UI and Signer
- Script outputs the installed version of both apps

Example output after a simulated signer upgrade to `5.2`:

```
########################################
### -> Verify UI and Signer attestations
########################################
Using 0490f5c9d15a0134bb019d2afd0bf297149738459706e7ac5be4abc350a1f818057224fce12ec9a65de18ec34d6e8c24db927835ea1692b14c32e9836a75dad609 as root authority
--------------------------------------------------------------------------------------------------------
UI verified with:
UD value: 474cc830bb9159299ca788a7527b561817ffa42f5d13f5429f14a95b0ee154f0
Derived public key (m/44'/0'/0'/0/0): 0332aba656b37e4e927806e1fe72323e1a7ca784fcc0eb9de2b1590f32f822b956
Authorized signer hash: 9f21e535d64ae9ab768fb2b6ab43e645c4d78a18318dca656de9c329f26098e9
Authorized signer iteration: 2
Installed UI hash: f060858f70c1832b2ac06c88fd741a4c8a098c974ad51122b2669d57c1f9d89c
Installed UI version: 5.1
--------------------------------------------------------------------------------------------------------
---------------------------------------------------------------------------------------
Signer verified with public keys:
m/44'/0'/0'/0/0:   0332aba656b37e4e927806e1fe72323e1a7ca784fcc0eb9de2b1590f32f822b956
m/44'/1'/0'/0/0:   03db12ee740f88bb412b66aaed99bd1908917d9321f6393643d1435c6b59f8ee4f
m/44'/1'/1'/0/0:   031867a30ec059b17d5901092b866d81fcf359fb528954c1ece903d1667a114a22
m/44'/1'/2'/0/0:   02078a43a98b19be5c4cacf2cc6ae2e2431de20561540ba40b344e8884ddc86816
m/44'/137'/0'/0/0: 028047542a7bc3007eed06e8e690d5447d89a5d394a351b189e33c40545afcbcd3
m/44'/137'/1'/0/0: 02bbf36ba664cfa81c659aceadc50c6b28462cb720b5dd3ec5afd8c8bd593ce5a8

Hash: db8fcfb3827812d17a87e645ac19469469e9f9626608cc33a5aa4d361d9dc3a8
Installed Signer hash: 9f21e535d64ae9ab768fb2b6ab43e645c4d78a18318dca656de9c329f26098e9
Installed Signer version: 5.2
---------------------------------------------------------------------------------------
```