### PR TITLE
Middleware SGX admin tooling

### DIFF
--- a/middleware/admin/misc.py
+++ b/middleware/admin/misc.py
@@ -24,9 +24,11 @@ import sys
 import time
 from getpass import getpass
 from ledger.hsm2dongle import HSM2Dongle
+from sgx.hsm2dongle import HSM2DongleSGX
 from ledger.pin import BasePin
 from .dongle_admin import DongleAdmin
 from .dongle_eth import DongleEth
+from comm.platform import Platform
 
 PIN_ERROR_MESSAGE = ("Invalid pin given. It must be exactly 8 alphanumeric "
                      "characters with at least one alphabetic character.")
@@ -68,7 +70,13 @@ def not_implemented(options):
 
 def get_hsm(debug):
     info("Connecting to HSM... ", False)
-    hsm = HSM2Dongle(debug)
+    if Platform.is_ledger():
+        hsm = HSM2Dongle(debug)
+    elif Platform.is_sgx():
+        hsm = HSM2DongleSGX(Platform.options("sgx_host"),
+                            Platform.options("sgx_port"), debug)
+    else:
+        raise AdminError("Platform not set or unknown platform")
     hsm.connect()
     info("OK")
     return hsm

--- a/middleware/admin/pubkeys.py
+++ b/middleware/admin/pubkeys.py
@@ -27,6 +27,7 @@ from ledger.hsm2dongle import HSM2Dongle
 from .misc import info, get_hsm, dispose_hsm, AdminError, wait_for_reconnection
 from .unlock import do_unlock
 from comm.bip32 import BIP32Path
+from comm.platform import Platform
 
 SIGNER_WAIT_TIME = 1  # second
 
@@ -65,7 +66,7 @@ def do_get_pubkeys(options):
     # Modes for which we can't get the public keys
     if mode in [HSM2Dongle.MODE.UNKNOWN, HSM2Dongle.MODE.BOOTLOADER]:
         raise AdminError(
-            "Device not in app mode. Disconnect and re-connect the ledger and try again")
+            f"Device not in app mode. {Platform.message("restart").capitalize()}")
 
     # Gather public keys
     pubkeys = {}

--- a/middleware/admin/unlock.py
+++ b/middleware/admin/unlock.py
@@ -32,6 +32,7 @@ from .misc import (
     AdminError,
     ask_for_pin,
 )
+from comm.platform import Platform
 
 
 def do_unlock(options, exit=True, no_exec=False, label=True):
@@ -65,8 +66,8 @@ def do_unlock(options, exit=True, no_exec=False, label=True):
 
     # Modes for which we can't unlock
     if mode == HSM2Dongle.MODE.UNKNOWN:
-        raise AdminError("Device mode unknown. Already unlocked? Otherwise disconnect "
-                         "and re-connect the ledger and try again")
+        raise AdminError("Device mode unknown. Already unlocked? Otherwise "
+                         f"{Platform.message("restart")} and try again")
     if mode == HSM2Dongle.MODE.SIGNER or mode == HSM2Dongle.MODE.UI_HEARTBEAT:
         raise AdminError("Device already unlocked")
 
@@ -87,9 +88,10 @@ def do_unlock(options, exit=True, no_exec=False, label=True):
         raise AdminError("Unable to unlock: PIN mismatch")
     info("PIN accepted")
 
+    # **** Ledger only ****
     # Exit the bootloader, go into menu (or, if app is properly signed, into
     # the app)
-    if exit:
+    if Platform.is_ledger() and exit:
         autoexec = not (options.no_exec or no_exec)
         info(f"Exiting to menu/app (execute signer: {bls(autoexec)})... ",
              options.verbose)

--- a/middleware/build/adm_sgx
+++ b/middleware/build/adm_sgx
@@ -1,0 +1,2 @@
+#!/bin/bash
+source $(dirname $0)/bld-docker adm_sgx

--- a/middleware/build/all
+++ b/middleware/build/all
@@ -6,8 +6,10 @@ BINDIR=$(realpath $BUILDDIR/../bin/)
 echo "Building all..."
 
 QUIET=1 $BUILDDIR/manager_ledger && \
+QUIET=1 $BUILDDIR/manager_sgx && \
 QUIET=1 $BUILDDIR/manager_tcp && \
 QUIET=1 $BUILDDIR/adm_ledger && \
+QUIET=1 $BUILDDIR/adm_sgx && \
 QUIET=1 $BUILDDIR/lbutils && \
 QUIET=1 $BUILDDIR/signapp && \
 echo "" && sha256sum $BINDIR/*.tgz

--- a/middleware/comm/platform.py
+++ b/middleware/comm/platform.py
@@ -1,0 +1,65 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021 RSK Labs Ltd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+class Platform:
+    LEDGER = "Ledger"
+    SGX = "SGX"
+    X86 = "X86"
+    VALID_PLATFORMS = [LEDGER, SGX, X86]
+
+    MESSAGES = {
+        LEDGER: {
+            "restart": "disconnect and re-connect the ledger nano",
+        },
+        SGX: {
+            "restart": "restart the SGX powHSM",
+        },
+        X86: {
+            "restart": "restart the TCPSigner",
+        }
+    }
+
+    _platform = None
+    _options = None
+
+    @classmethod
+    def set(klass, plf, options={}):
+        if plf not in klass.VALID_PLATFORMS:
+            raise RuntimeError("Invalid platform given")
+        klass._platform = plf
+        klass._options = options
+
+    @classmethod
+    def is_ledger(klass):
+        return klass._platform == Platform.LEDGER
+
+    @classmethod
+    def is_sgx(klass):
+        return klass._platform == Platform.SGX
+
+    @classmethod
+    def options(klass, key):
+        return klass._options[key]
+
+    @classmethod
+    def message(klass, key):
+        return klass.MESSAGES[klass._platform][key]

--- a/middleware/ledger/protocol.py
+++ b/middleware/ledger/protocol.py
@@ -22,6 +22,7 @@
 
 import time
 from comm.protocol import HSM2Protocol, HSM2ProtocolError, HSM2ProtocolInterrupt
+from comm.platform import Platform
 from ledger.hsm2dongle import (
     HSM2Dongle,
     HSM2DongleBaseError,
@@ -45,11 +46,6 @@ class HSM2ProtocolLedger(HSM2Protocol):
 
     # Required minimum number of pin retries available to proceed with unlocking
     MIN_AVAILABLE_RETRIES = 2
-
-    # Default user messages
-    MESSAGES = {
-        "restart": "restart the powHSM"
-    }
 
     def __init__(self, pin, dongle):
         super().__init__()
@@ -78,7 +74,7 @@ class HSM2ProtocolLedger(HSM2Protocol):
             self.logger.info(
                 "Could not determine onboarded status. If unlocked, "
                 + "please enter the signing app and rerun the manager. Otherwise,"
-                + f"{self.MESSAGES["restart"]} and try again"
+                + f"{Platform.message("restart")} and try again"
             )
             raise HSM2ProtocolInterrupt()
 
@@ -201,12 +197,12 @@ class HSM2ProtocolLedger(HSM2Protocol):
                     raise Exception("Dongle reported fail to change pin. Pin invalid?")
                 self.pin.commit_change()
                 self.logger.info(
-                    f"PIN changed. Please {self.MESSAGES["restart"]}"
+                    f"PIN changed. Please {Platform.message("restart")}"
                 )
             except Exception as e:
                 self.pin.abort_change()
                 self.logger.error(
-                    f"Error changing PIN: %s. Please {self.MESSAGES["restart"]} "
+                    f"Error changing PIN: %s. Please {Platform.message("restart")} "
                     "and try again", format(e),
                 )
             finally:

--- a/middleware/manager_ledger.py
+++ b/middleware/manager_ledger.py
@@ -25,6 +25,7 @@ from ledger.hsm2dongle import HSM2Dongle
 from mgr.runner import ManagerRunner
 from ledger.pin import FileBasedPin
 from user.options import UserOptionParser
+from comm.platform import Platform
 
 
 def load_pin(user_options):
@@ -39,18 +40,13 @@ def load_pin(user_options):
     return pin
 
 
-def configure_protocol_messages(protocol):
-    protocol.MESSAGES = {
-        "restart": "disconnect and reconnect the ledger nano",
-    }
-
-
 if __name__ == "__main__":
+    Platform.set(Platform.LEDGER)
     user_options = UserOptionParser("Start the powHSM manager for Ledger",
                                     with_pin=True).parse()
 
     runner = ManagerRunner("powHSM manager",
                            lambda options: HSM2Dongle(options.io_debug),
-                           load_pin, configure_protocol_messages)
+                           load_pin)
 
     runner.run(user_options)

--- a/middleware/manager_sgx.py
+++ b/middleware/manager_sgx.py
@@ -25,6 +25,7 @@ from sgx.hsm2dongle import HSM2DongleSGX
 from mgr.runner import ManagerRunner
 from ledger.pin import FileBasedPin
 from user.options import UserOptionParser
+from comm.platform import Platform
 
 
 def load_pin(user_options):
@@ -39,13 +40,8 @@ def load_pin(user_options):
     return pin
 
 
-def configure_protocol_messages(protocol):
-    protocol.MESSAGES = {
-        "restart": "restart the SGX powHSM",
-    }
-
-
 if __name__ == "__main__":
+    Platform.set(Platform.SGX)
     user_options = UserOptionParser("Start the powHSM manager for SGX",
                                     with_pin=True,
                                     with_tcpconn=True,
@@ -56,6 +52,6 @@ if __name__ == "__main__":
                            lambda options: HSM2DongleSGX(options.tcpconn_host,
                                                          options.tcpconn_port,
                                                          options.io_debug),
-                           load_pin, configure_protocol_messages)
+                           load_pin)
 
     runner.run(user_options)

--- a/middleware/manager_tcp.py
+++ b/middleware/manager_tcp.py
@@ -23,15 +23,11 @@
 from ledger.hsm2dongle_tcp import HSM2DongleTCP
 from mgr.runner import ManagerRunner
 from user.options import UserOptionParser
-
-
-def configure_protocol_messages(protocol):
-    protocol.MESSAGES = {
-        "restart": "restart the TCPSigner",
-    }
+from comm.platform import Platform
 
 
 if __name__ == "__main__":
+    Platform.set(Platform.X86)
     user_options = UserOptionParser("Start the powHSM manager for TCPSigner",
                                     with_pin=False,
                                     with_tcpconn=True,
@@ -41,7 +37,6 @@ if __name__ == "__main__":
                            lambda options: HSM2DongleTCP(options.tcpconn_host,
                                                          options.tcpconn_port,
                                                          options.io_debug),
-                           load_pin=lambda options: None,
-                           configure_protocol=configure_protocol_messages)
+                           load_pin=lambda options: None)
 
     runner.run(user_options)

--- a/middleware/mgr/runner.py
+++ b/middleware/mgr/runner.py
@@ -29,11 +29,10 @@ import logging
 
 
 class ManagerRunner:
-    def __init__(self, name, create_dongle, load_pin, configure_protocol=None):
+    def __init__(self, name, create_dongle, load_pin):
         self.name = name
         self.create_dongle = create_dongle
         self.load_pin = load_pin
-        self.configure_protocol = configure_protocol
 
     def run(self, user_options):
         configure_logging(user_options.logconfigfilepath)
@@ -52,8 +51,6 @@ class ManagerRunner:
             else:
                 logger.info("Using protocol version 2")
                 protocol = HSM2ProtocolLedger(pin, dongle)
-            if self.configure_protocol:
-                self.configure_protocol(protocol)
             server = TCPServer(user_options.host, user_options.port, protocol)
             server.run()
         except PinError as e:

--- a/middleware/tests/admin/test_adm_sgx.py
+++ b/middleware/tests/admin/test_adm_sgx.py
@@ -1,0 +1,171 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021 RSK Labs Ltd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import sys
+from argparse import Namespace
+from unittest import TestCase
+from unittest.mock import call, patch
+from adm_sgx import main
+import logging
+
+logging.disable(logging.CRITICAL)
+
+
+class TestAdmLedger(TestCase):
+    def setUp(self):
+        self.old_stdout = sys.stdout
+        self.DEFAULT_OPTIONS = {
+            "sgx_host": "localhost",
+            "sgx_port": 7777,
+            "any_pin": False,
+            "new_pin": None,
+            "no_unlock": False,
+            "operation": None,
+            "output_file_path": None,
+            "pin": None,
+            "verbose": False,
+        }
+
+    def tearDown(self):
+        sys.stdout = self.old_stdout
+
+    @patch("adm_sgx.do_unlock")
+    def test_unlock(self, do_unlock):
+        expected_options = {
+            **self.DEFAULT_OPTIONS,
+            'operation': 'unlock',
+            'pin': 'a-pin',
+        }
+        expected_call_args_list = [
+            call(Namespace(**expected_options)),
+            call(Namespace(**expected_options))
+        ]
+
+        with patch('sys.argv', ['adm_sgx.py', '-p', 'a-pin', 'unlock']):
+            with self.assertRaises(SystemExit) as e:
+                main()
+        self.assertEqual(e.exception.code, 0)
+
+        with patch('sys.argv', ['adm_sgx.py', '--pin', 'a-pin', 'unlock']):
+            with self.assertRaises(SystemExit) as e:
+                main()
+        self.assertEqual(e.exception.code, 0)
+
+        self.assertTrue(do_unlock.called)
+        self.assertEqual(do_unlock.call_count, 2)
+        self.assertEqual(expected_call_args_list, do_unlock.call_args_list)
+
+    @patch("adm_sgx.do_onboard")
+    def test_onboard(self, do_onboard):
+        expected_options = {
+            **self.DEFAULT_OPTIONS,
+            'operation': 'onboard',
+            'pin': 'a-pin',
+        }
+
+        expected_call_args_list = [
+            call(Namespace(**expected_options)),
+            call(Namespace(**expected_options))
+        ]
+
+        with patch('sys.argv',
+                   ['adm_sgx.py', '-p', 'a-pin', 'onboard']):
+            with self.assertRaises(SystemExit) as e:
+                main()
+        self.assertEqual(e.exception.code, 0)
+
+        with patch('sys.argv',
+                   ['adm_sgx.py', '--pin', 'a-pin', 'onboard']):
+            with self.assertRaises(SystemExit) as e:
+                main()
+        self.assertEqual(e.exception.code, 0)
+
+        self.assertTrue(do_onboard.called)
+        self.assertEqual(expected_call_args_list, do_onboard.call_args_list)
+
+    @patch("adm_sgx.do_get_pubkeys")
+    def test_pubkeys(self, do_get_pubkeys):
+        expected_options = {
+            **self.DEFAULT_OPTIONS,
+            'no_unlock': True,
+            'operation': 'pubkeys',
+            'output_file_path': 'a-path',
+            'pin': 'a-pin',
+            'sgx_host': '1.2.3.4',
+        }
+
+        expected_call_args_list = [
+            call(Namespace(**expected_options)),
+            call(Namespace(**expected_options))
+        ]
+
+        with patch('sys.argv', ['adm_sgx.py', '-p', 'a-pin', '-o', 'a-path', '-u',
+                                '-s', '1.2.3.4', 'pubkeys']):
+            with self.assertRaises(SystemExit) as e:
+                main()
+        self.assertEqual(e.exception.code, 0)
+
+        with patch('sys.argv',
+                   ['adm_sgx.py',
+                    '--host', '1.2.3.4',
+                    '--pin', 'a-pin',
+                    '--output', 'a-path',
+                    '--nounlock',
+                    'pubkeys']):
+            with self.assertRaises(SystemExit) as e:
+                main()
+        self.assertEqual(e.exception.code, 0)
+
+        self.assertTrue(do_get_pubkeys.called)
+        self.assertEqual(expected_call_args_list, do_get_pubkeys.call_args_list)
+
+    @patch("adm_sgx.do_changepin")
+    def test_changepin(self, do_changepin):
+        expected_options = {
+            **self.DEFAULT_OPTIONS,
+            'any_pin': True,
+            'new_pin': 'new-pin',
+            'operation': 'changepin',
+            'pin': 'old-pin',
+            'sgx_port': 4567,
+        }
+        expected_call_args_list = [
+            call(Namespace(**expected_options)),
+            call(Namespace(**expected_options))
+        ]
+
+        with patch('sys.argv', ['adm_sgx.py', '-p', 'old-pin', '-n', 'new-pin',
+                                '-r', '4567', '-a', 'changepin']):
+            with self.assertRaises(SystemExit) as e:
+                main()
+        self.assertEqual(e.exception.code, 0)
+
+        with patch('sys.argv', ['adm_sgx.py',
+                                '--newpin', 'new-pin', '--anypin', 'changepin',
+                                '--port', '4567', '--pin', 'old-pin']):
+            with self.assertRaises(SystemExit) as e:
+                main()
+        self.assertEqual(e.exception.code, 0)
+
+        self.assertTrue(do_changepin.called)
+        self.assertEqual(do_changepin.call_count, 2)
+        self.assertEqual(expected_call_args_list, do_changepin.call_args_list)

--- a/middleware/tests/admin/test_unlock.py
+++ b/middleware/tests/admin/test_unlock.py
@@ -24,6 +24,7 @@ from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
 from admin.misc import AdminError
+from comm.platform import Platform
 from admin.unlock import do_unlock
 from ledger.hsm2dongle import HSM2Dongle
 from parameterized import parameterized
@@ -37,6 +38,7 @@ logging.disable(logging.CRITICAL)
 @patch("admin.unlock.get_hsm")
 class TestUnlock(TestCase):
     def setUp(self):
+        Platform.set(Platform.LEDGER)
         self.valid_pin = '1234ABCD'
         self.invalid_pin = '123456789'
 


### PR DESCRIPTION
- Added `Platform` abstraction to manage common platform parameters
- Added onboard support to `HSM2DongleSGX`
- Implemented SGX admin tool
    - Implemented main SGX admin tool entrypoint with onboard, unlock, pin change and public key gathering commands
    - Misc `get_hsm` function now accounts for current `Platform` to acquire a connection
    - Updated specific admin modules to account for difference between platforms for specific operations
    - Now setting `Platform` within Ledger admin tool
- Updated build scripts to account for SGX manager and admin
- Replaced protocol platform-specific configuration for text messages with `Platform` messages
- Added and updated unit tests

