### PR TITLE
SGX reproducible builds

### DIFF
--- a/docker/sgx/Dockerfile
+++ b/docker/sgx/Dockerfile
@@ -4,20 +4,8 @@ FROM openenclavedockerregistry.azurecr.io/oetools-20.04:2024.10.2391
 RUN apt-get update && \
     apt-get install -y apt-utils vim && \
     apt-get install -y tar && \
-    apt-get install -y xz-utils && \
     apt-get install -y curl && \
-    apt-get install -y git && \
-    apt-get install -y clang-11 && \
-    apt-get install -y libssl-dev && \
-    apt-get install -y gdb && \
-    apt-get install -y libsgx-enclave-common && \
-    apt-get install -y libsgx-quote-ex && \
-    apt-get install -y libprotobuf17 && \
-    apt-get install -y libsgx-dcap-ql && \
-    apt-get install -y libsgx-dcap-ql-dev && \
-    apt-get install -y az-dcap-client && \
     apt-get install -y open-enclave && \
-    apt-get install -y gcc && \
     apt-get install -y make
 
 # Create directory to host symlinks to Open Enclave static libraries

--- a/docker/sgx/Dockerfile
+++ b/docker/sgx/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
     apt-get install -y apt-utils vim && \
     apt-get install -y tar && \
     apt-get install -y curl && \
-    apt-get install -y open-enclave && \
+    apt-get install -y open-enclave=0.19.4 && \
     apt-get install -y make
 
 # Create directory to host symlinks to Open Enclave static libraries

--- a/docker/sgx/Dockerfile
+++ b/docker/sgx/Dockerfile
@@ -1,4 +1,4 @@
-FROM openenclavedockerregistry.azurecr.io/oetools-20.04:2023.11.21100
+FROM openenclavedockerregistry.azurecr.io/oetools-20.04:2024.10.2391
 
 # Install dependencies
 RUN apt-get update && \

--- a/firmware/src/sgx/Makefile
+++ b/firmware/src/sgx/Makefile
@@ -38,13 +38,13 @@ POWHSM_SRC_DIR = ../powhsm/src
 COMMON_SRC_DIR = ../common/src
 
 ## Untrusted source files
-UNTRUSTED_SRC =  $(wildcard $(SGX_UNTRUSTED_SRC_DIR)/*.c)
+UNTRUSTED_SRC =  $(sort $(wildcard $(SGX_UNTRUSTED_SRC_DIR)/*.c))
 
 ## Trusted source files
-TRUSTED_SRC =  $(wildcard $(SGX_TRUSTED_SRC_DIR)/*.c)
-TRUSTED_SRC += $(wildcard $(HAL_TRUSTED_SRC_DIR)/*.c)
-TRUSTED_SRC += $(wildcard $(POWHSM_SRC_DIR)/*.c)
-TRUSTED_SRC += $(wildcard $(COMMON_SRC_DIR)/*.c)
+TRUSTED_SRC =  $(sort $(wildcard $(SGX_TRUSTED_SRC_DIR)/*.c))
+TRUSTED_SRC += $(sort $(wildcard $(HAL_TRUSTED_SRC_DIR)/*.c))
+TRUSTED_SRC += $(sort $(wildcard $(POWHSM_SRC_DIR)/*.c))
+TRUSTED_SRC += $(sort $(wildcard $(COMMON_SRC_DIR)/*.c))
 
 # Enclave definition files
 EDL_FILE = $(SGX_SRC_DIR)/$(ENCLAVE_NAME).edl


### PR DESCRIPTION
Ensure that SGX builds are reproducible:
- Removes unnecessary dependencies from the SGX Dockerfile
- Freezes open-enclave version to `0.19.4`
- Sorts source files to ensure the build order is deterministic
- Updates SGX Docker base-image to `2024.10.2391`