### PR TITLE
Adds MRENCLAVE and digest information to SGX build scripts

### DIFF
--- a/build-dist-sgx
+++ b/build-dist-sgx
@@ -52,6 +52,14 @@ $ROOT_DIR/firmware/build/build-sgx $CHECKPOINT $DIFFICULTY $NETWORK > /dev/null
 cp $ROOT_DIR/firmware/src/sgx/bin/hsmsgx $HSM_DIR/
 cp $ROOT_DIR/firmware/src/sgx/bin/hsmsgx_enclave.signed $HSM_DIR/
 
+HOST_HASH=$(sha256sum $ROOT_DIR/firmware/src/sgx/bin/hsmsgx | cut -d ' ' -f 1)
+ENCLAVE_HASH=$($ROOT_DIR/firmware/build/extract-mrenclave $ROOT_DIR/firmware/src/sgx/bin/hsmsgx_enclave.signed)
+echo "$HSM_DIR/hsmsgx:"
+echo $HOST_HASH
+echo
+echo "$HSM_DIR/hsmsgx_enclave.signed"
+echo "$ENCLAVE_HASH"
+
 echo
 echo -e "\e[32mBuild complete.\e[0m"
 

--- a/firmware/build/build-sgx
+++ b/firmware/build/build-sgx
@@ -40,3 +40,20 @@ BUILD_CMD="\$SGX_ENVSETUP && make clean $BUILD_TARGET CHECKPOINT=$1 TARGET_DIFFI
 DOCKER_USER="$(id -u):$(id -g)"
 
 docker run -t --rm --user $DOCKER_USER -w /hsm2/firmware/src/sgx -v ${HSM_ROOT}:/hsm2 ${DOCKER_IMAGE} /bin/bash -c "$BUILD_CMD"
+
+if [[ $? -ne 0 ]]; then
+    echo "Build failed"
+    exit 1
+fi
+
+HOST_BIN=$HSM_ROOT/firmware/src/sgx/bin/hsmsgx
+ENCLAVE_BIN=$HSM_ROOT/firmware/src/sgx/bin/hsmsgx_enclave.signed
+
+echo "*******************"
+echo "Build successful."
+echo "$(realpath $HOST_BIN --relative-to=$HSM_ROOT):"
+sha256sum $HOST_BIN | cut -d ' ' -f 1
+echo ""
+echo "$(realpath $ENCLAVE_BIN --relative-to=$HSM_ROOT):"
+$BUILD_ROOT/extract-mrenclave $ENCLAVE_BIN
+echo "*******************"


### PR DESCRIPTION
Output generated for all build variations:

build-sgx:
```
*******************
Build successful.
firmware/src/sgx/bin/hsmsgx:
ca290b9c59708a036ce7e79725e0986007aa1776da46e68429e3e9d52be8259f

firmware/src/sgx/bin/hsmsgx_enclave.signed:
digest: b9c7f97ad8b89c72aedf309a04f95d4f452a519633eb731d0604c96df85404bc
mrenclave: 1ef21c85da473a175f0d683930590e8d5b03f2e04ab4535ec94cc039d457f633
*******************
```

build-sgx-debug:
```
*******************
Build successful.
firmware/src/sgx/bin/hsmsgx:
ca290b9c59708a036ce7e79725e0986007aa1776da46e68429e3e9d52be8259f

firmware/src/sgx/bin/hsmsgx_enclave.signed:
digest: 6fc62e154b245849abb1d6f93951260e86da3732de23c576ce59c45325c43511
mrenclave: 83398f3a88c004df199ad22478099e2dd75c78474f427a50b60d377261ef3337
*******************
```

build-sgx-sim:
```
*******************
Build successful.
firmware/src/sgx/bin/hsmsgx:
6fe84efc82106c1cf651ae1f3896b35353e92abe71cebae79b7afed550c0c11f

firmware/src/sgx/bin/hsmsgx_enclave.signed:
digest: 308921dbd221f85b216baa41ee2cd539b9a8d2e6ed6e9447a490587581c3c360
mrenclave: 35210f065e88624c836aa40d7ca9c488171e914069a5312d2f8e99b5e0756e63
*******************
```

build-dist-sgx:
```
Building into /tmp/dist-sgx with checkpoint 0x00f06dcff26ec8b4d373fbd53ee770e9348d9bd6a247ad4c86e82ceb3c2130ac, minimum difficulty 0x7c50933098, network testnet and UI iteration ...
Copying files and creating directories...

Building middleware...
Building SGX distribution binaries...
..
9bbc2ffe05d7e44565e8d631e967b51abbe0f5f4ca2e4f0222c8918fc92fdee8  /home/italo/workspace/rsk-powhsm/middleware/bin/manager_sgx.tgz
81270237f4e201dcb6822d91b7614496e11b100c85a714fb2e9f531e39164133  /home/italo/workspace/rsk-powhsm/middleware/bin/adm_sgx.tgz

Building SGX apps...
/tmp/dist-sgx/hsm/hsmsgx:
ca290b9c59708a036ce7e79725e0986007aa1776da46e68429e3e9d52be8259f

/tmp/dist-sgx/hsm/hsmsgx_enclave.signed
digest: b9c7f97ad8b89c72aedf309a04f95d4f452a519633eb731d0604c96df85404bc
mrenclave: 1ef21c85da473a175f0d683930590e8d5b03f2e04ab4535ec94cc039d457f633

Build complete.
```