### PR TITLE
Fixes coverage report for feature/sgx branch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@ name: "Code coverage"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "feature/sgx" ]
 
 jobs:
   coverage:

--- a/firmware/coverage/gen-coverage
+++ b/firmware/coverage/gen-coverage
@@ -15,7 +15,6 @@ if [[ $1 == "exec" ]]; then
     COVERAGE=y $REPOROOT/firmware/src/sgx/test/run-all.sh
     COVERAGE=y $REPOROOT/firmware/src/ledger/ui/test/run-all.sh
     COVERAGE=y $REPOROOT/firmware/src/ledger/signer/test/run-all.sh
-    COVERAGE=y $REPOROOT/firmware/src/tcpsigner/test/run-all.sh
     COVERAGE=y $REPOROOT/firmware/src/hal/sgx/test/run-all.sh
 
     # Run tcpsigner test suite

--- a/firmware/coverage/gen-coverage
+++ b/firmware/coverage/gen-coverage
@@ -37,7 +37,7 @@ if [[ $1 == "exec" ]]; then
     # Remove unwanted coverage info (test files, tcpsigner, x86 HAL implementation, mock files)
     lcov --remove $BASEDIR/coverage.info "*/test_*.c" --output-file $BASEDIR/coverage.info
     lcov --remove $BASEDIR/coverage.info "*/tcpsigner/src/*" --output-file $BASEDIR/coverage.info
-    lcov --remove $BASEDIR/coverage.info "*/hal/src/x86/*" --output-file $BASEDIR/coverage.info
+    lcov --remove $BASEDIR/coverage.info "*/hal/x86/src/*" --output-file $BASEDIR/coverage.info
     lcov --remove $BASEDIR/coverage.info "*/mock_*.c" --output-file $BASEDIR/coverage.info
     # Generate report and summary
     genhtml $BASEDIR/coverage.info --output $BASEDIR/output -p $SRCDIR -t "powHSM firmware"

--- a/firmware/coverage/gen-coverage
+++ b/firmware/coverage/gen-coverage
@@ -10,12 +10,13 @@ if [[ $1 == "exec" ]]; then
     find $REPOROOT/firmware -name "*.gcno" -o -name "*.gcda" | xargs rm -f
 
     # Run unit tests with coverage generation
-    COVERAGE=y $REPOROOT/firmware/src/common/test/run-all.sh
-    COVERAGE=y $REPOROOT/firmware/src/powhsm/test/run-all.sh
-    COVERAGE=y $REPOROOT/firmware/src/sgx/test/run-all.sh
-    COVERAGE=y $REPOROOT/firmware/src/ledger/ui/test/run-all.sh
-    COVERAGE=y $REPOROOT/firmware/src/ledger/signer/test/run-all.sh
-    COVERAGE=y $REPOROOT/firmware/src/hal/sgx/test/run-all.sh
+    # The `exec` argument is used for all scripts, since we are running them inside a docker container
+    COVERAGE=y $REPOROOT/firmware/src/common/test/run-all.sh exec
+    COVERAGE=y $REPOROOT/firmware/src/powhsm/test/run-all.sh exec
+    COVERAGE=y $REPOROOT/firmware/src/sgx/test/run-all.sh exec
+    COVERAGE=y $REPOROOT/firmware/src/ledger/ui/test/run-all.sh exec
+    COVERAGE=y $REPOROOT/firmware/src/ledger/signer/test/run-all.sh exec
+    COVERAGE=y $REPOROOT/firmware/src/hal/sgx/test/run-all.sh exec
 
     # Run tcpsigner test suite
     pushd $REPOROOT/firmware/src/tcpsigner > /dev/null

--- a/firmware/src/common/test/run-all.sh
+++ b/firmware/src/common/test/run-all.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
-BASEDIR=$(dirname $0)
-TESTDIRS="bigdigits_helper ints memutil"
-TESTDIRS=${1:-"$TESTDIRS"}
 
-for d in $TESTDIRS; do
-    echo "******************************"
-    echo "Testing $d..."
-    echo "******************************"
-    cd "$BASEDIR/$d"
-    make clean test || exit $?
-    cd - > /dev/null
-done
+if [[ $1 == "exec" ]]; then
+    BASEDIR=$(realpath $(dirname $0))
+    TESTDIRS="bigdigits_helper ints memutil"
+    for d in $TESTDIRS; do
+        echo "******************************"
+        echo "Testing $d..."
+        echo "******************************"
+        cd "$BASEDIR/$d"
+        make clean test || exit $?
+        cd - > /dev/null
+    done
+    exit 0
+else
+    # Script directory
+    REPOROOT=$(realpath $(dirname $0)/../../../../)
+    SCRIPT=$(realpath $0 --relative-to=$REPOROOT)
+
+    $REPOROOT/docker/mware/do-notty-nousb /hsm2 "./$SCRIPT exec"
+fi

--- a/firmware/src/hal/common/test/run-all.sh
+++ b/firmware/src/hal/common/test/run-all.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
-BASEDIR=$(dirname $0)
-TESTDIRS="sha256"
-TESTDIRS=${1:-"$TESTDIRS"}
 
-for d in $TESTDIRS; do
-    echo "******************************"
-    echo "Testing $d..."
-    echo "******************************"
-    cd "$BASEDIR/$d"
-    make clean test || exit $?
-    cd - > /dev/null
-done
+if [[ $1 == "exec" ]]; then
+    BASEDIR=$(realpath $(dirname $0))
+    TESTDIRS="sha256"
+    for d in $TESTDIRS; do
+        echo "******************************"
+        echo "Testing $d..."
+        echo "******************************"
+        cd "$BASEDIR/$d"
+        make clean test || exit $?
+        cd - > /dev/null
+    done
+    exit 0
+else
+    # Script directory
+    REPOROOT=$(realpath $(dirname $0)/../../../../../)
+    SCRIPT=$(realpath $0 --relative-to=$REPOROOT)
+
+    $REPOROOT/docker/mware/do-notty-nousb /hsm2 "./$SCRIPT exec"
+fi

--- a/firmware/src/hal/sgx/test/run-all.sh
+++ b/firmware/src/hal/sgx/test/run-all.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
-ROOTDIR=$(dirname $0)/../../../../..
-TESTDIR=$(realpath $(dirname $0) --relative-to $ROOTDIR)
-TESTDIRS="nvmem secret_store seed"
-TESTDIRS=${1:-"$TESTDIRS"}
 
-for d in $TESTDIRS; do
-    echo "******************************"
-    echo "Testing $d..."
-    echo "******************************"
-    $ROOTDIR/docker/mware/do-notty-nousb /hsm2/$TESTDIR/$d "make clean test" || exit $?
-done
+if [[ $1 == "exec" ]]; then
+    BASEDIR=$(realpath $(dirname $0))
+    TESTDIRS="nvmem secret_store seed"
+    for d in $TESTDIRS; do
+        echo "******************************"
+        echo "Testing $d..."
+        echo "******************************"
+        cd "$BASEDIR/$d"
+        make clean test || exit $?
+        cd - > /dev/null
+    done
+    exit 0
+else
+    # Script directory
+    REPOROOT=$(realpath $(dirname $0)/../../../../..)
+    SCRIPT=$(realpath $0 --relative-to=$REPOROOT)
+
+    $REPOROOT/docker/mware/do-notty-nousb /hsm2 "./$SCRIPT exec"
+fi

--- a/firmware/src/hal/x86/test/run-all.sh
+++ b/firmware/src/hal/x86/test/run-all.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
-ROOTDIR=$(dirname $0)/../../../../..
-TESTDIR=$(realpath $(dirname $0) --relative-to $ROOTDIR)
-TESTDIRS="bip32 endian hmac_sha256 hmac_sha512 keccak256"
-TESTDIRS=${1:-"$TESTDIRS"}
 
-for d in $TESTDIRS; do
-    echo "******************************"
-    echo "Testing $d..."
-    echo "******************************"
-    $ROOTDIR/docker/mware/do-notty-nousb /hsm2/$TESTDIR/$d "make clean test" || exit $?
-done
+if [[ $1 == "exec" ]]; then
+    BASEDIR=$(realpath $(dirname $0))
+    TESTDIRS="bip32 endian hmac_sha256 hmac_sha512 keccak256"
+    for d in $TESTDIRS; do
+        echo "******************************"
+        echo "Testing $d..."
+        echo "******************************"
+        cd "$BASEDIR/$d"
+        make clean test || exit $?
+        cd - > /dev/null
+    done
+    exit 0
+else
+    # Script directory
+    REPOROOT=$(realpath $(dirname $0)/../../../../..)
+    SCRIPT=$(realpath $0 --relative-to=$REPOROOT)
+
+    $REPOROOT/docker/mware/do-notty-nousb /hsm2 "./$SCRIPT exec"
+fi

--- a/firmware/src/ledger/signer/test/run-all.sh
+++ b/firmware/src/ledger/signer/test/run-all.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
-BASEDIR=$(dirname $0)
-TESTDIRS="signer_ux"
-TESTDIRS=${1:-"$TESTDIRS"}
 
-for d in $TESTDIRS; do
-    echo "******************************"
-    echo "Testing $d..."
-    echo "******************************"
-    cd "$BASEDIR/$d"
-    make clean test || exit $?
-    cd - > /dev/null
-done
+if [[ $1 == "exec" ]]; then
+    BASEDIR=$(realpath $(dirname $0))
+    TESTDIRS="signer_ux"
+    for d in $TESTDIRS; do
+        echo "******************************"
+        echo "Testing $d..."
+        echo "******************************"
+        cd "$BASEDIR/$d"
+        make clean test || exit $?
+        cd - > /dev/null
+    done
+    exit 0
+else
+    # Script directory
+    REPOROOT=$(realpath $(dirname $0)/../../../../../)
+    SCRIPT=$(realpath $0 --relative-to=$REPOROOT)
+
+    $REPOROOT/docker/mware/do-notty-nousb /hsm2 "./$SCRIPT exec"
+fi

--- a/firmware/src/ledger/ui/test/run-all.sh
+++ b/firmware/src/ledger/ui/test/run-all.sh
@@ -1,13 +1,22 @@
 #!/bin/bash
-BASEDIR=$(dirname $0)
-TESTDIRS="attestation bootloader onboard pin signer_authorization ui_comm ui_heartbeat unlock ux_handlers"
-TESTDIRS=${1:-"$TESTDIRS"}
 
-for d in $TESTDIRS; do
-    echo "******************************"
-    echo "Testing $d..."
-    echo "******************************"
-    cd "$BASEDIR/$d"
-    make clean test || exit $?
-    cd - > /dev/null
-done
+if [[ $1 == "exec" ]]; then
+    BASEDIR=$(realpath $(dirname $0))
+    TESTDIRS="attestation bootloader onboard pin signer_authorization ui_comm ui_heartbeat unlock ux_handlers"
+    for d in $TESTDIRS; do
+        echo "******************************"
+        echo "Testing $d..."
+        echo "******************************"
+        cd "$BASEDIR/$d"
+        make clean test || exit $?
+        cd - > /dev/null
+    done
+    exit 0
+else
+    # Script directory
+    REPOROOT=$(realpath $(dirname $0)/../../../../../)
+    SCRIPT=$(realpath $0 --relative-to=$REPOROOT)
+
+    $REPOROOT/docker/mware/do-notty-nousb /hsm2 "./$SCRIPT exec"
+fi
+

--- a/firmware/src/powhsm/test/btctx/test_btctx.c
+++ b/firmware/src/powhsm/test/btctx/test_btctx.c
@@ -54,9 +54,11 @@ int read_hex_file(const char* file_name, unsigned char** buffer, size_t* len) {
         fread(tmp, 2, 1, f);
         read_hex(tmp, 2, *buffer + off);
     }
-    fclose(f);
-
     if (ferror(f)) {
+        return -1;
+    }
+
+    if (fclose(f)) {
         return -1;
     }
 

--- a/firmware/src/powhsm/test/run-all.sh
+++ b/firmware/src/powhsm/test/run-all.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
-BASEDIR=$(dirname $0)
-TESTDIRS="btcscript btctx difficulty srlp svarint trie"
-TESTDIRS=${1:-"$TESTDIRS"}
 
-for d in $TESTDIRS; do
-    echo "******************************"
-    echo "Testing $d..."
-    echo "******************************"
-    cd "$BASEDIR/$d"
-    make clean test || exit $?
-    cd - > /dev/null
-done
+if [[ $1 == "exec" ]]; then
+    BASEDIR=$(realpath $(dirname $0))
+    TESTDIRS="btcscript btctx difficulty srlp svarint trie"
+    for d in $TESTDIRS; do
+        echo "******************************"
+        echo "Testing $d..."
+        echo "******************************"
+        cd "$BASEDIR/$d"
+        make clean test || exit $?
+        cd - > /dev/null
+    done
+    exit 0
+else
+    # Script directory
+    REPOROOT=$(realpath $(dirname $0)/../../../../)
+    SCRIPT=$(realpath $0 --relative-to=$REPOROOT)
+
+    $REPOROOT/docker/mware/do-notty-nousb /hsm2 "./$SCRIPT exec"
+fi

--- a/firmware/src/powhsm/test/srlp/test_srlp.c
+++ b/firmware/src/powhsm/test/srlp/test_srlp.c
@@ -204,9 +204,12 @@ int read_block_file(const char* file_name, char** buffer, size_t* len) {
 
     *buffer = malloc(*len);
     fread(*buffer, *len, 1, f);
-    fclose(f);
 
     if (ferror(f)) {
+        return -1;
+    }
+
+    if (fclose(f)) {
         return -1;
     }
 

--- a/firmware/src/sgx/test/run-all.sh
+++ b/firmware/src/sgx/test/run-all.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
-BASEDIR=$(dirname $0)
-TESTDIRS="system"
-TESTDIRS=${1:-"$TESTDIRS"}
 
-for d in $TESTDIRS; do
-    echo "******************************"
-    echo "Testing $d..."
-    echo "******************************"
-    cd "$BASEDIR/$d"
-    make clean test || exit $?
-    cd - > /dev/null
-done
+if [[ $1 == "exec" ]]; then
+    BASEDIR=$(realpath $(dirname $0))
+    TESTDIRS="system"
+    for d in $TESTDIRS; do
+        echo "******************************"
+        echo "Testing $d..."
+        echo "******************************"
+        cd "$BASEDIR/$d"
+        make clean test || exit $?
+        cd - > /dev/null
+    done
+    exit 0
+else
+    # Script directory
+    REPOROOT=$(realpath $(dirname $0)/../../../../)
+    SCRIPT=$(realpath $0 --relative-to=$REPOROOT)
+
+    $REPOROOT/docker/mware/do-notty-nousb /hsm2 "./$SCRIPT exec"
+fi


### PR DESCRIPTION
There were two problems with the coverage report for the feature branch:

1 - The `coverage.yml` workflow was not set to run on pushes to `feature/sgx`, which means that there was no coverage badge available for version `5.3.x`, which was causing the broken coverage badge.

2 - Some unit tests were failing inside the `gen-coverage` script, since internally they try would try to start a new instance of the `hsm:mware` docker container. Since the `gen-coverage` script itself runs in a docker container, these tests were failing. This was introduced basically because these unit tests would fail in the `run-tests` workflow if they were set to run in the host machine. This was fixed by standardizing all the `run-all.sh` scripts for the unit tests not to assume they need to start their docker instance, and move that logic to the `run-test` workflow instead.

NOTE: after that change, an intermittent bug in `srlp` and `btctx` unit tests became more frequent, so the last commit fixes it (details in the commit message).