### PR TITLE
Certificate v2 validator

### DIFF
--- a/middleware/admin/certificate.py
+++ b/middleware/admin/certificate.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from .certificate_v1 import HSMCertificate, HSMCertificateElement
+from .certificate_v1 import HSMCertificate, HSMCertificateRoot, HSMCertificateElement
 from .certificate_v2 import HSMCertificateV2, HSMCertificateV2ElementSGXQuote, \
                             HSMCertificateV2ElementSGXAttestationKey, \
                             HSMCertificateV2ElementX509

--- a/middleware/admin/certificate_v2.py
+++ b/middleware/admin/certificate_v2.py
@@ -27,8 +27,7 @@ from .utils import is_nonempty_hex_string
 
 class HSMCertificateV2Element:
     def __init__(self):
-        raise RuntimeError("Cannot instantiate an "
-                           "abstract HSMCertificateV2Element")
+        raise NotImplementedError("Cannot instantiate a HSMCertificateV2Element")
 
     @classmethod
     def from_dict(kls, element_map):
@@ -55,6 +54,22 @@ class HSMCertificateV2Element:
     @property
     def signed_by(self):
         return self._signed_by
+
+    def get_value(self):
+        raise NotImplementedError(f"{type(self).__name__} can't provide a value")
+
+    def get_pubkey(self):
+        # TODO: this should yield not implemented
+        # TODO: implementation should be down to each specific subclass
+        return None
+
+    def is_valid(self, certifier):
+        # TODO: this should yield not implemented
+        # TODO: implementation should be down to each specific subclass
+        return True
+
+    def get_tweak(self):
+        return None
 
 
 class HSMCertificateV2ElementSGXQuote(HSMCertificateV2Element):
@@ -88,6 +103,9 @@ class HSMCertificateV2ElementSGXQuote(HSMCertificateV2Element):
     @property
     def signature(self):
         return self._signature.hex()
+
+    def get_value(self):
+        return self.custom_data
 
     def to_dict(self):
         return {
@@ -189,7 +207,3 @@ class HSMCertificateV2(HSMCertificate):
     ROOT_ELEMENT = "sgx_root"
     ELEMENT_BASE_CLASS = HSMCertificateV2Element
     ELEMENT_FACTORY = HSMCertificateV2Element.from_dict
-
-    def validate_and_get_values(self, raw_root_pubkey_hex):
-        # TODO
-        pass

--- a/middleware/admin/verify_ledger_attestation.py
+++ b/middleware/admin/verify_ledger_attestation.py
@@ -26,7 +26,7 @@ import secp256k1 as ec
 import re
 from .misc import info, head, AdminError
 from .utils import is_nonempty_hex_string
-from .certificate import HSMCertificate
+from .certificate import HSMCertificate, HSMCertificateRoot
 
 
 UI_MESSAGE_HEADER_REGEX = re.compile(b"^HSM:UI:(5.[0-9])")
@@ -69,6 +69,10 @@ def do_verify_attestation(options):
         if not is_nonempty_hex_string(options.root_authority):
             raise AdminError("Invalid root authority")
         root_authority = options.root_authority
+    try:
+        root_authority = HSMCertificateRoot(root_authority)
+    except ValueError:
+        raise AdminError("Invalid root authority")
     info(f"Using {root_authority} as root authority")
 
     # Load the given public keys and compute

--- a/middleware/tests/admin/test_certificate_v1.py
+++ b/middleware/tests/admin/test_certificate_v1.py
@@ -26,7 +26,7 @@ import secp256k1 as ec
 
 from unittest import TestCase
 from unittest.mock import call, patch, mock_open
-from admin.certificate import HSMCertificate, HSMCertificateElement
+from admin.certificate import HSMCertificate, HSMCertificateRoot, HSMCertificateElement
 
 
 class TestHSMCertificate(TestCase):
@@ -240,6 +240,7 @@ class TestHSMCertificate(TestCase):
     def test_validate_and_get_values_ok(self):
         root_privkey = ec.PrivateKey()
         root_pubkey = root_privkey.pubkey.serialize(compressed=False).hex()
+        root_of_trust = HSMCertificateRoot(root_pubkey)
         device_privkey = ec.PrivateKey()
         device_pubkey = device_privkey.pubkey.serialize(compressed=False).hex()
         att_pubkey = ec.PrivateKey().pubkey.serialize(compressed=False).hex()
@@ -273,48 +274,12 @@ class TestHSMCertificate(TestCase):
         self.assertEqual({
             'attestation': (True, att_pubkey, None),
             'device': (True, device_pubkey, None)
-        }, cert.validate_and_get_values(root_pubkey))
-
-    def test_create_and_get_values_invalid_pubkey(self):
-        root_privkey = ec.PrivateKey()
-        device_privkey = ec.PrivateKey()
-        device_pubkey = device_privkey.pubkey.serialize(compressed=False).hex()
-        att_pubkey = ec.PrivateKey().pubkey.serialize(compressed=False).hex()
-
-        att_msg = 'ff' + att_pubkey
-        att_sig = device_privkey.ecdsa_serialize(
-            device_privkey.ecdsa_sign(bytes.fromhex(att_msg))).hex()
-
-        device_msg = os.urandom(16).hex() + device_pubkey
-        device_sig = root_privkey.ecdsa_serialize(
-            root_privkey.ecdsa_sign(bytes.fromhex(device_msg))).hex()
-
-        cert = HSMCertificate({
-            "version": 1,
-            "targets": ["attestation", "device"],
-            "elements": [
-                {
-                    "name": "attestation",
-                    "message": att_msg,
-                    "signature": att_sig,
-                    "signed_by": "device"
-                },
-                {
-                    "name": "device",
-                    "message": device_msg,
-                    "signature": device_sig,
-                    "signed_by": "root"
-                }]
-        })
-
-        self.assertEqual({
-            'attestation': (False, 'root'),
-            'device': (False, 'root')
-        }, cert.validate_and_get_values('invalid-pubkey'))
+        }, cert.validate_and_get_values(root_of_trust))
 
     def test_validate_and_get_values_invalid_element(self):
         root_privkey = ec.PrivateKey()
         root_pubkey = root_privkey.pubkey.serialize(compressed=False).hex()
+        root_of_trust = HSMCertificateRoot(root_pubkey)
         device_privkey = ec.PrivateKey()
         device_pubkey = device_privkey.pubkey.serialize(compressed=False).hex()
         att_pubkey = ec.PrivateKey().pubkey.serialize(compressed=False).hex()
@@ -347,7 +312,7 @@ class TestHSMCertificate(TestCase):
         self.assertEqual({
             'attestation': (False, 'attestation'),
             'device': (True, device_pubkey, None)
-        }, cert.validate_and_get_values(root_pubkey))
+        }, cert.validate_and_get_values(root_of_trust))
 
     def test_validate_and_get_values_invalid_elements(self):
         att_privkey = ec.PrivateKey()

--- a/middleware/tests/admin/test_certificate_v2.py
+++ b/middleware/tests/admin/test_certificate_v2.py
@@ -41,6 +41,18 @@ class TestHSMCertificateV2(TestCase):
         cert = HSMCertificateV2(TEST_CERTIFICATE)
         self.assertEqual(TEST_CERTIFICATE, cert.to_dict())
 
+    def test_validate_and_get_values_value(self):
+        cert = HSMCertificateV2(TEST_CERTIFICATE)
+        self.assertEqual({
+            "quote": (
+                True,
+                "504f5748534d3a352e343a3a736778f36f7bc09aab50c0886a442b2d04b18186720bd"
+                "a7a753643066cd0bc0a4191800c4d091913d39750dc8975adbdd261bd10c1c2e110fa"
+                "a47cfbe30e740895552bbdcb3c17c7aee714cec8ad900341bfd987b452280220dcbd6"
+                "e7191f67ea4209b00000000000000000000000000000000",
+                None)
+            }, cert.validate_and_get_values('a-root-of-trust'))
+
 
 class TestHSMCertificateV2Element(TestCase):
     def test_from_dict_unknown_type(self):


### PR DESCRIPTION
- Replacing plain public key in validate_and_get_values method for a root of trust object with get_pubkey method
- Using inherited validate_and_get_values in HSMCertificateV2
- Added HSMCertificateRoot to certificate version 1 to act as root of trust in existing validations
- Updated verify ledger attestation accordingly
- Added and updated unit tests