### PR TITLE
Certificate V2 x509_pem type element validation

### DIFF
--- a/middleware/admin/certificate_v2.py
+++ b/middleware/admin/certificate_v2.py
@@ -259,7 +259,7 @@ class HSMCertificateV2ElementX509(HSMCertificateV2Element):
             # IMPORTANT: for now, we only allow verifying the validity of an
             # HSMCertificateV2ElementX509 using another HSMCertificateV2ElementX509
             # instance as certifier. That way, we simplify the validation procedure
-            # and ensure maximum compatibility wrt the underlying library used
+            # and ensure maximum use of the underlying library's capabilities
             # (cryptography)
             if not isinstance(certifier, type(self)):
                 return False

--- a/middleware/admin/verify_sgx_attestation.py
+++ b/middleware/admin/verify_sgx_attestation.py
@@ -53,6 +53,9 @@ def do_verify_attestation(options):
     info(f"Attempting to gather root authority from {root_authority}...")
     try:
         root_of_trust = get_root_of_trust(root_authority)
+        info("Attempting to validate self-signed root authority...")
+        if not root_of_trust.is_valid(root_of_trust):
+            raise ValueError("Failed to validate self-signed root of trust")
     except Exception as e:
         raise AdminError(f"Invalid root authority {root_authority}: {e}")
     info(f"Using {root_authority} as root authority")


### PR DESCRIPTION
- Implemented `HSMCertificateV2ElementX509`'s `is_valid` method
- Added root of trust element validation in SGX attestation verification
- Added and updated unit tests