### PR TITLE
Adds unsigned enclave binary to distribution

### DIFF
--- a/build-dist-sgx
+++ b/build-dist-sgx
@@ -50,6 +50,7 @@ echo -e "\e[33mBuilding SGX apps...\e[0m"
 # since we don't actually need it in our current scheme)
 $ROOT_DIR/firmware/build/build-sgx $CHECKPOINT $DIFFICULTY $NETWORK > /dev/null
 cp $ROOT_DIR/firmware/src/sgx/bin/hsmsgx $HSM_DIR/
+cp $ROOT_DIR/firmware/src/sgx/bin/hsmsgx_enclave $HSM_DIR/
 cp $ROOT_DIR/firmware/src/sgx/bin/hsmsgx_enclave.signed $HSM_DIR/
 
 HOST_HASH=$(sha256sum $ROOT_DIR/firmware/src/sgx/bin/hsmsgx | cut -d ' ' -f 1)

--- a/firmware/build/README.md
+++ b/firmware/build/README.md
@@ -70,7 +70,7 @@ For example, to build host and enclave with checkpoint `0x00f06dcff26ec8b4d373fb
 ~/repo> firmware/build/build-sgx 0x00f06dcff26ec8b4d373fbd53ee770e9348d9bd6a247ad4c86e82ceb3c2130ac 0x7c50933098 testnet
 ```
 
-Once the build is complete, the binaries will be placed under `<HSM_PROJECT_ROOT>/firmware/src/sgx/bin` with the names `hsmsgx` for the host and `hsmsgx_enclave.signed` for the signed enclave.
+Once the build is complete, the binaries will be placed under `<HSM_PROJECT_ROOT>/firmware/src/sgx/bin` with the names `hsmsgx` for the host, `hsmsgx_enclave` and `hsmsgx_enclave.signed` for the unsigned and signed enclave binaries, respectively.
 
 ### Reproducible builds
 


### PR DESCRIPTION
The hash of the unsigned enclave will be included in the reproducible builds information, so it also needs to be part of the distribution