### PR TITLE
Version 5.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [5.2.2] - 20/01/2025
+
+### Features/enhancements
+
+- Implemented OSSF scorecard on CI
+
+### Fixes
+
+- Fixed middleware docker image build
+- Fixed minor scorecard findings
+- Bumped debian, aflplusplus docker images
+- Bumpled GH actions codeql, upload-artifact
+
 ## [5.2.1] - 14/11/2024
 
 ### Fixes

--- a/firmware/src/ledger/ui/src/defs.h
+++ b/firmware/src/ledger/ui/src/defs.h
@@ -31,6 +31,6 @@
 // Version and patchlevel
 #define VERSION_MAJOR 0x05
 #define VERSION_MINOR 0x02
-#define VERSION_PATCH 0x01
+#define VERSION_PATCH 0x02
 
 #endif // __DEFS_H

--- a/firmware/src/ledger/ui/test/onboard/test_onboard.c
+++ b/firmware/src/ledger/ui/test/onboard/test_onboard.c
@@ -313,11 +313,11 @@ void test_is_onboarded() {
 
     G_device_onboarded = true;
     assert(5 == is_onboarded());
-    ASSERT_APDU("\x80\x01\x05\x02\x01");
+    ASSERT_APDU("\x80\x01\x05\x02\x02");
 
     G_device_onboarded = false;
     assert(5 == is_onboarded());
-    ASSERT_APDU("\x80\x00\x05\x02\x01");
+    ASSERT_APDU("\x80\x00\x05\x02\x02");
 }
 
 int main() {

--- a/firmware/src/powhsm/src/defs.h
+++ b/firmware/src/powhsm/src/defs.h
@@ -30,6 +30,6 @@
 // Version and patchlevel
 #define VERSION_MAJOR 0x05
 #define VERSION_MINOR 0x02
-#define VERSION_PATCH 0x01
+#define VERSION_PATCH 0x02
 
 #endif // __DEFS_H

--- a/middleware/ledger/protocol.py
+++ b/middleware/ledger/protocol.py
@@ -37,8 +37,8 @@ from comm.bitcoin import get_unsigned_tx, get_tx_hash
 
 class HSM2ProtocolLedger(HSM2Protocol):
     # Current manager supported versions for HSM UI and HSM SIGNER (<=)
-    UI_VERSION = HSM2FirmwareVersion(5, 2, 1)
-    APP_VERSION = HSM2FirmwareVersion(5, 2, 1)
+    UI_VERSION = HSM2FirmwareVersion(5, 2, 2)
+    APP_VERSION = HSM2FirmwareVersion(5, 2, 2)
 
     # Amount of time to wait to make sure the app is opened
     OPEN_APP_WAIT = 1  # second

--- a/middleware/tests/ledger/test_protocol.py
+++ b/middleware/tests/ledger/test_protocol.py
@@ -49,7 +49,7 @@ class TestHSM2ProtocolLedger(TestCase):
         self.dongle.disconnect = Mock()
         self.dongle.is_onboarded = Mock(return_value=True)
         self.dongle.get_current_mode = Mock(return_value=HSM2Dongle.MODE.SIGNER)
-        self.dongle.get_version = Mock(return_value=HSM2FirmwareVersion(5, 2, 1))
+        self.dongle.get_version = Mock(return_value=HSM2FirmwareVersion(5, 2, 2))
         self.dongle.get_signer_parameters = Mock(return_value=Mock(
             min_required_difficulty=123))
         self.protocol = HSM2ProtocolLedger(self.pin, self.dongle)


### PR DESCRIPTION
- Bump version to 5.2.2
- Updated version references in firmware, middleware and unit tests
- Updated CHANGELOG