### PR TITLE
Fixes formatting error identified by C linter

### DIFF
--- a/firmware/src/sgx/src/untrusted/main.c
+++ b/firmware/src/sgx/src/untrusted/main.c
@@ -104,7 +104,7 @@ static void finalise_with(int exit_code) {
 }
 
 static void finalise(int signum) {
-    (void) signum; // Suppress unused parameter warning
+    (void)signum; // Suppress unused parameter warning
 
     finalise_with(0);
 }


### PR DESCRIPTION
The latest PR that was merged to `feature/sgx` fails the C linter test. Since this was pushed before the fix for the linter in the CI, this branch was not tested for it