### PR TITLE
Added APDU buffer pointer validation to SGX enclave init sequence

### DIFF
--- a/firmware/src/sgx/src/trusted/system.c
+++ b/firmware/src/sgx/src/trusted/system.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <openenclave/enclave.h>
 
 #include "hal/constants.h"
 #include "hal/communication.h"
@@ -166,6 +167,14 @@ bool system_init(unsigned char* msg_buffer, size_t msg_buffer_size) {
             msg_buffer_size);
         return false;
     }
+
+    // Validate that the APDU buffer is entirely outside the enclave
+    // memory space
+    if (!oe_is_outside_enclave(msg_buffer, msg_buffer_size)) {
+        LOG("APDU buffer memory area not outside the enclave\n");
+        return false;
+    }
+
     apdu_buffer = msg_buffer;
     apdu_buffer_size = msg_buffer_size;
 

--- a/firmware/src/sgx/test/common/common.mk
+++ b/firmware/src/sgx/test/common/common.mk
@@ -6,7 +6,8 @@ HALSGXSRCDIR = ../../../hal/sgx/src/trusted
 POWHSMSRCDIR = ../../../powhsm/src
 COMMONDIR = ../../../common/src
 
-CFLAGS  = -iquote $(TESTCOMMONDIR)
+CFLAGS = -Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-function
+CFLAGS += -I $(TESTCOMMONDIR)
 CFLAGS += -iquote $(SGXTRUSTEDDIR)
 CFLAGS += -iquote $(SGXUNTRUSTEDDIR)
 CFLAGS += -iquote $(HALINCDIR)

--- a/firmware/src/sgx/test/common/openenclave/enclave.h
+++ b/firmware/src/sgx/test/common/openenclave/enclave.h
@@ -1,0 +1,27 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 RSK Labs Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <stdbool.h>
+
+bool oe_is_outside_enclave(const void *ptr, size_t size);

--- a/firmware/src/sgx/test/keyvalue_store/test_keyvalue_store.c
+++ b/firmware/src/sgx/test/keyvalue_store/test_keyvalue_store.c
@@ -89,24 +89,23 @@ void test_save_retrieve() {
 
     struct {
         char* key;
-        uint8_t* data;
-    } input_data[] = {
-        {"a-key", (uint8_t*)"some piece of data"},
-        {"another-key", (uint8_t*)"another piece of data"},
-        {"yet-another-key", (uint8_t*)"yet another piece of data"},
-        {"the-last-key", (uint8_t*)"the last piece of data"}};
+        char* data;
+    } input_data[] = {{"a-key", "some piece of data"},
+                      {"another-key", "another piece of data"},
+                      {"yet-another-key", "yet another piece of data"},
+                      {"the-last-key", "the last piece of data"}};
     size_t num_inputs = sizeof(input_data) / sizeof(input_data[0]);
 
     for (size_t i = 0; i < num_inputs; i++) {
         save_and_assert_success(input_data[i].key,
-                                input_data[i].data,
-                                strlen((char*)input_data[i].data));
+                                (uint8_t*)input_data[i].data,
+                                strlen(input_data[i].data));
     }
 
     for (size_t i = 0; i < num_inputs; i++) {
         assert_key_value(input_data[i].key,
-                         input_data[i].data,
-                         strlen((char*)input_data[i].data));
+                         (uint8_t*)input_data[i].data,
+                         strlen(input_data[i].data));
     }
 }
 
@@ -116,11 +115,11 @@ void test_kvstore_exists() {
 
     struct {
         char* key;
-        uint8_t* data;
+        char* data;
     } existing_keys[] = {
-        {"first-key", (uint8_t*)"some piece of data"},
-        {"second-key", (uint8_t*)"another piece of data"},
-        {"third-key", (uint8_t*)"yet another piece of data"},
+        {"first-key", "some piece of data"},
+        {"second-key", "another piece of data"},
+        {"third-key", "yet another piece of data"},
     };
     size_t num_existing_keys = sizeof(existing_keys) / sizeof(existing_keys[0]);
 
@@ -134,8 +133,8 @@ void test_kvstore_exists() {
 
     for (size_t i = 0; i < num_existing_keys; i++) {
         save_and_assert_success(existing_keys[i].key,
-                                existing_keys[i].data,
-                                strlen((char*)existing_keys[i].data));
+                                (uint8_t*)existing_keys[i].data,
+                                strlen(existing_keys[i].data));
     }
 
     for (size_t i = 0; i < num_existing_keys; i++) {
@@ -153,23 +152,23 @@ void test_save_remove() {
 
     struct {
         char* key;
-        uint8_t* data;
+        char* data;
         bool remove;
     } input_data[] = {
-        {"first-key", (uint8_t*)"some piece of data", false},
-        {"second-key", (uint8_t*)"another piece of data", true},
-        {"third-key", (uint8_t*)"yet another piece of data", true},
-        {"fourth-key", (uint8_t*)"the last piece of data", false},
+        {"first-key", "some piece of data", false},
+        {"second-key", "another piece of data", true},
+        {"third-key", "yet another piece of data", true},
+        {"fourth-key", "the last piece of data", false},
     };
     size_t num_inputs = sizeof(input_data) / sizeof(input_data[0]);
 
     for (size_t i = 0; i < num_inputs; i++) {
         save_and_assert_success(input_data[i].key,
-                                input_data[i].data,
-                                strlen((char*)input_data[i].data));
+                                (uint8_t*)input_data[i].data,
+                                strlen(input_data[i].data));
         assert_key_value(input_data[i].key,
-                         input_data[i].data,
-                         strlen((char*)input_data[i].data));
+                         (uint8_t*)input_data[i].data,
+                         strlen(input_data[i].data));
     }
 
     // Remove selected keys
@@ -185,8 +184,8 @@ void test_save_remove() {
             assert_key_exists(input_data[i].key, false);
         } else {
             assert_key_value(input_data[i].key,
-                             input_data[i].data,
-                             strlen((char*)input_data[i].data));
+                             (uint8_t*)input_data[i].data,
+                             strlen(input_data[i].data));
         }
     }
 }
@@ -197,7 +196,7 @@ void test_filename() {
 
     struct {
         char* key;
-        uint8_t* data;
+        char* data;
         char* filename;
     } input_data[] = {
         {"first-key", "data for the first key", "kvstore-first-key.dat"},
@@ -232,7 +231,7 @@ void test_sanitize_key() {
     struct {
         char* key;
         char* filename;
-        uint8_t* data;
+        char* data;
     } input_data[] = {
         {"onlyletters", "kvstore-onlyletters.dat", "data1"},
         {"123456", "kvstore-123456.dat", "data2"},
@@ -257,18 +256,20 @@ void test_sanitize_key() {
     // Save data to each key and assert that the file name and contents are
     // correct
     for (size_t i = 0; i < num_inputs; i++) {
-        save_and_assert_success(
-            input_data[i].key, input_data[i].data, strlen(input_data[i].data));
+        save_and_assert_success(input_data[i].key,
+                                (uint8_t*)input_data[i].data,
+                                strlen(input_data[i].data));
         assert_file_exists(input_data[i].filename, true);
         assert_file_contents(input_data[i].filename,
-                             input_data[i].data,
+                             (uint8_t*)input_data[i].data,
                              strlen(input_data[i].data));
     }
 
     // Ensure data can be retrieved with the original key
     for (size_t i = 0; i < num_inputs; i++) {
-        assert_key_value(
-            input_data[i].key, input_data[i].data, strlen(input_data[i].data));
+        assert_key_value(input_data[i].key,
+                         (uint8_t*)input_data[i].data,
+                         strlen(input_data[i].data));
     }
 }
 

--- a/firmware/src/sgx/test/system/test_system.c
+++ b/firmware/src/sgx/test/system/test_system.c
@@ -64,6 +64,7 @@ typedef struct mock_calls_counter {
     int nvmem_init_count;
     int nvmem_register_block_count;
     int sest_init_count;
+    int oe_is_outside_enclave_count;
 } mock_calls_counter_t;
 
 typedef struct nvmem_register_block_args {
@@ -106,6 +107,7 @@ typedef struct mock_force_fail {
     bool endorsement_init;
     bool nvmem_register_block;
     bool sest_init;
+    bool oe_is_outside_enclave;
 } mock_force_fail_t;
 
 typedef struct mock_data {
@@ -166,6 +168,11 @@ try_context_t* G_try_last_open_context = &G_try_last_open_context_var;
 unsigned char G_io_apdu_buffer[IO_APDU_BUFFER_SIZE];
 
 // Mock implementation of dependencies
+bool oe_is_outside_enclave(const void* ptr, size_t size) {
+    MOCK_CALL(oe_is_outside_enclave);
+    return true;
+}
+
 void hsm_init() {
     NUM_CALLS(hsm_init)++;
 }
@@ -351,6 +358,7 @@ void test_init_success() {
     printf("Test system_init success...\n");
 
     assert(system_init(G_io_apdu_buffer, sizeof(G_io_apdu_buffer)));
+    assert(NUM_CALLS(oe_is_outside_enclave) == 1);
     assert(NUM_CALLS(sest_init) == 1);
     assert(NUM_CALLS(access_init) == 1);
     assert(NUM_CALLS(seed_init) == 1);
@@ -381,6 +389,23 @@ void test_init_fails_invalid_buf_size() {
     printf("Test system_init fails with invalid buffer size...\n");
 
     assert(!system_init(G_io_apdu_buffer, sizeof(G_io_apdu_buffer) - 1));
+    ASSERT_NOT_CALLED(oe_is_outside_enclave);
+    ASSERT_NOT_CALLED(sest_init);
+    ASSERT_NOT_CALLED(access_init);
+    ASSERT_NOT_CALLED(seed_init);
+    ASSERT_NOT_CALLED(communication_init);
+    ASSERT_NOT_CALLED(endorsement_init);
+    ASSERT_NOT_CALLED(nvmem_init);
+    teardown();
+}
+
+void test_init_fails_invalid_buf_memarea() {
+    setup();
+    printf("Test system_init fails with invalid buffer memory area...\n");
+
+    FORCE_FAIL(oe_is_outside_enclave, true);
+    assert(!system_init(G_io_apdu_buffer, sizeof(G_io_apdu_buffer)));
+    assert(NUM_CALLS(oe_is_outside_enclave) == 1);
     ASSERT_NOT_CALLED(sest_init);
     ASSERT_NOT_CALLED(access_init);
     ASSERT_NOT_CALLED(seed_init);
@@ -396,6 +421,7 @@ void test_init_fails_when_sest_init_fails() {
 
     FORCE_FAIL(sest_init, true);
     assert(!system_init(G_io_apdu_buffer, sizeof(G_io_apdu_buffer)));
+    assert(NUM_CALLS(oe_is_outside_enclave) == 1);
     assert(NUM_CALLS(sest_init) == 1);
     ASSERT_NOT_CALLED(access_init);
     ASSERT_NOT_CALLED(seed_init);
@@ -411,6 +437,7 @@ void test_init_fails_when_access_init_fails() {
 
     FORCE_FAIL(access_init, true);
     assert(!system_init(G_io_apdu_buffer, sizeof(G_io_apdu_buffer)));
+    assert(NUM_CALLS(oe_is_outside_enclave) == 1);
     assert(NUM_CALLS(sest_init) == 1);
     assert(NUM_CALLS(access_init) == 1);
     ASSERT_NOT_CALLED(seed_init);
@@ -426,6 +453,7 @@ void test_init_fails_when_seed_init_fails() {
 
     FORCE_FAIL(seed_init, true);
     assert(!system_init(G_io_apdu_buffer, sizeof(G_io_apdu_buffer)));
+    assert(NUM_CALLS(oe_is_outside_enclave) == 1);
     assert(NUM_CALLS(sest_init) == 1);
     assert(NUM_CALLS(access_init) == 1);
     assert(NUM_CALLS(seed_init) == 1);
@@ -441,6 +469,7 @@ void test_init_fails_when_communication_init_fails() {
 
     FORCE_FAIL(communication_init, true);
     assert(!system_init(G_io_apdu_buffer, sizeof(G_io_apdu_buffer)));
+    assert(NUM_CALLS(oe_is_outside_enclave) == 1);
     assert(NUM_CALLS(sest_init) == 1);
     assert(NUM_CALLS(access_init) == 1);
     assert(NUM_CALLS(seed_init) == 1);
@@ -456,6 +485,7 @@ void test_init_fails_when_endorsement_init_fails() {
 
     FORCE_FAIL(endorsement_init, true);
     assert(!system_init(G_io_apdu_buffer, sizeof(G_io_apdu_buffer)));
+    assert(NUM_CALLS(oe_is_outside_enclave) == 1);
     assert(NUM_CALLS(sest_init) == 1);
     assert(NUM_CALLS(access_init) == 1);
     assert(NUM_CALLS(seed_init) == 1);
@@ -471,7 +501,7 @@ void test_init_fails_when_nvmem_register_block_fails() {
 
     FORCE_NVMEM_FAIL_ON_KEY("bcstate");
     assert(!system_init(G_io_apdu_buffer, sizeof(G_io_apdu_buffer)));
-    assert(NUM_CALLS(sest_init) == 1);
+    assert(NUM_CALLS(oe_is_outside_enclave) == 1);
     assert(NUM_CALLS(sest_init) == 1);
     assert(NUM_CALLS(access_init) == 1);
     assert(NUM_CALLS(seed_init) == 1);
@@ -487,6 +517,8 @@ void test_init_fails_when_nvmem_register_block_fails() {
 
     FORCE_NVMEM_FAIL_ON_KEY("bcstate_updating");
     assert(!system_init(G_io_apdu_buffer, sizeof(G_io_apdu_buffer)));
+    assert(NUM_CALLS(oe_is_outside_enclave) == 2);
+    assert(NUM_CALLS(sest_init) == 2);
     assert(NUM_CALLS(access_init) == 2);
     assert(NUM_CALLS(seed_init) == 2);
     assert(NUM_CALLS(communication_init) == 2);
@@ -513,6 +545,7 @@ void test_init_fails_when_nvmem_load_fails() {
 
     FORCE_FAIL(nvmem_load, true);
     assert(!system_init(G_io_apdu_buffer, sizeof(G_io_apdu_buffer)));
+    assert(NUM_CALLS(oe_is_outside_enclave) == 1);
     assert(NUM_CALLS(sest_init) == 1);
     assert(NUM_CALLS(access_init) == 1);
     assert(NUM_CALLS(seed_init) == 1);
@@ -958,6 +991,7 @@ void test_invalid_cmd_not_handled() {
 int main() {
     test_init_success();
     test_init_fails_invalid_buf_size();
+    test_init_fails_invalid_buf_memarea();
     test_init_fails_when_sest_init_fails();
     test_init_fails_when_access_init_fails();
     test_init_fails_when_seed_init_fails();


### PR DESCRIPTION
- Using `oe_is_outside_enclave` to validate the APDU buffer in `system_init`
- Added unit test case