### PR TITLE
Adds header checking to secret store

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -128,11 +128,17 @@ jobs:
           cp rsk-powhsm/firmware/src/sgx/bin/hsmsgx_enclave.signed \
               hsm-integration-test/docker/sgx
           echo abcd1234 > hsm-integration-test/docker/manager/pin.txt
-          echo -n abcd1234 > hsm-integration-test/docker/sgx/kvstore-password.dat
-          echo -en "\x03" > hsm-integration-test/docker/sgx/kvstore-retries.dat
-          echo -en "\x03" > hsm-integration-test/docker/sgx/kvstore-retries.dat
+          echo -n "password" | sha256sum | awk '{print $1}' \
+            | xxd -r -p > hsm-integration-test/docker/sgx/kvstore-password.dat
+          echo -n abcd1234 >> hsm-integration-test/docker/sgx/kvstore-password.dat
+          echo -n "retries" | sha256sum | awk '{print $1}' \
+            | xxd -r -p > hsm-integration-test/docker/sgx/kvstore-retries.dat
+          echo -en "\x03" >> hsm-integration-test/docker/sgx/kvstore-retries.dat
+          echo -n "seed" | sha256sum | awk '{print $1}' \
+            | xxd -r -p > hsm-integration-test/docker/sgx/kvstore-seed.dat
           dd if=/dev/urandom bs=1 count=32 \
-              of=hsm-integration-test/docker/sgx/kvstore-seed.dat
+              of=hsm-integration-test/docker/sgx/kvstore-seed.dat \
+              seek=32
           echo "SGX_SIM=yes" >> "$GITHUB_ENV"
 
       - name: Run HSM integration tests

--- a/firmware/src/hal/sgx/src/trusted/secret_store.c
+++ b/firmware/src/hal/sgx/src/trusted/secret_store.c
@@ -106,10 +106,17 @@ static size_t add_header(const char* key,
  *
  * @param key The key to validate the header against.
  * @param data The buffer containing the data to validate.
+ * @param data_length The length of the data buffer.
  *
  * @returns true if the header is valid, false otherwise.
  */
-static bool is_header_valid(const char* key, const uint8_t* data) {
+static bool is_header_valid(const char* key,
+                            const uint8_t* data,
+                            size_t data_length) {
+    if (data_length < HASH_LENGTH) {
+        return false;
+    }
+
     uint8_t expected_header[HASH_LENGTH];
     add_header(key, NULL, 0, expected_header, HASH_LENGTH);
 
@@ -286,7 +293,7 @@ uint8_t sest_read(char* key, uint8_t* dest, size_t dest_length) {
         goto sest_read_error;
     }
 
-    if (!is_header_valid(key, G_unsealed_buffer)) {
+    if (!is_header_valid(key, G_unsealed_buffer, unsealed_length)) {
         LOG("Secret header validation failed for key <%s>\n", key);
         goto sest_read_error;
     }

--- a/firmware/src/hal/sgx/test/mock/mock_ocall.c
+++ b/firmware/src/hal/sgx/test/mock/mock_ocall.c
@@ -114,9 +114,11 @@ void mock_ocall_kvstore_fail_next(mock_kvstore_failure_type_t failure) {
     G_next_failure = failure;
 }
 
-void mock_ocall_kstore_assert_value(char* key, const uint8_t* value) {
+void mock_ocall_kstore_assert_value(char* key,
+                                    const uint8_t* value,
+                                    size_t length) {
     ASSERT_STR_EQUALS(key, G_kvstore_key);
-    ASSERT_STR_EQUALS(value, G_kvstore_data);
+    ASSERT_MEMCMP(value, G_kvstore_data, length);
 }
 
 bool mock_ocall_kstore_key_exists(char* key) {

--- a/firmware/src/hal/sgx/test/mock/mock_ocall.h
+++ b/firmware/src/hal/sgx/test/mock/mock_ocall.h
@@ -75,7 +75,9 @@ oe_result_t mock_ocall_kvstore_remove(bool* _retval, char* key);
  */
 void mock_ocall_kvstore_fail_next(mock_kvstore_failure_type_t failure);
 
-void mock_ocall_kstore_assert_value(char* key, const uint8_t* value);
+void mock_ocall_kstore_assert_value(char* key,
+                                    const uint8_t* value,
+                                    size_t length);
 
 bool mock_ocall_kstore_key_exists(char* key);
 

--- a/firmware/src/hal/sgx/test/mock/mock_seal.c
+++ b/firmware/src/hal/sgx/test/mock/mock_seal.c
@@ -128,8 +128,8 @@ void assert_oe_seal_called_with(const void* plugin_id,
                                 size_t additional_data_size) {
     assert(G_oe_seal_args.plugin_id == plugin_id &&
            memcmp(&G_oe_seal_args.settings, settings, sizeof(*settings)) == 0 &&
+           memcmp(G_oe_seal_args.plaintext, plaintext, plaintext_size) == 0 &&
            G_oe_seal_args.settings_count == settings_count &&
-           G_oe_seal_args.plaintext == plaintext &&
            G_oe_seal_args.plaintext_size == plaintext_size &&
            G_oe_seal_args.additional_data == additional_data &&
            G_oe_seal_args.additional_data_size == additional_data_size);

--- a/firmware/src/hal/sgx/test/mock/openenclave/corelibc/stdlib.h
+++ b/firmware/src/hal/sgx/test/mock/openenclave/corelibc/stdlib.h
@@ -25,6 +25,7 @@
 #ifndef __MOCK_OE_STDLIB_H
 #define __MOCK_OE_STDLIB_H
 
+#define oe_malloc(size) malloc(size)
 #define oe_free(ptr) free(ptr)
 
 #endif // #ifndef __MOCK_OE_STDLIB_H

--- a/firmware/src/hal/sgx/test/mock/openenclave/corelibc/stdlib.h
+++ b/firmware/src/hal/sgx/test/mock/openenclave/corelibc/stdlib.h
@@ -25,7 +25,6 @@
 #ifndef __MOCK_OE_STDLIB_H
 #define __MOCK_OE_STDLIB_H
 
-#define oe_malloc(size) malloc(size)
 #define oe_free(ptr) free(ptr)
 
 #endif // #ifndef __MOCK_OE_STDLIB_H

--- a/firmware/src/hal/sgx/test/secret_store/Makefile
+++ b/firmware/src/hal/sgx/test/secret_store/Makefile
@@ -23,7 +23,7 @@
 include ../common/common.mk
 
 PROG = test.out
-OBJS = secret_store.o test_secret_store.o platform.o mock_seal.o mock_ocall.o
+OBJS = secret_store.o test_secret_store.o platform.o mock_seal.o mock_ocall.o sha256.o
 
 all: $(PROG)
 


### PR DESCRIPTION
Introduces a header to the data to be sealed by the secret store.

Now a header is added to the secret before sending it to the seal API.
The header contains a type constant that is verified when the secret
is retrieved. This prevents the files containing the sealed blobs from
being swapped and treated as valid data by the system.