### PR TITLE
Version 5.4.1 release (#286)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           repository: rootstock/hsm-integration-test
-          ref: 5.3.0.plus
+          ref: 5.4.0.plus
           path: hsm-integration-test
           ssh-key: ${{ secrets.HSM_INTEGRATION_TEST_SSH_KEY }}
 
@@ -114,7 +114,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           repository: rootstock/hsm-integration-test
-          ref: 5.3.0.plus
+          ref: 5.4.0.plus
           path: hsm-integration-test
           ssh-key: ${{ secrets.HSM_INTEGRATION_TEST_SSH_KEY }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [5.4.1] - 07/02/2025
+
+### Features/enhancements
+
+- Unified pin/password policy across platforms
+- Disabled CapturePFGPExceptions on non-debug and non-simulator builds
+- Added key-based headers and header checks to secrets
+- Moved bip32_derive_private and dependent libraries to SGX's HAL only
+- Moved bip32_parse_path to x86 only
+
+### Fixes
+
+- Increased pip install socket timeout for middleware Dockerfile
+- Fixed potential memory leak on SGX's NVmem module
+- Pinned all actions/checkout by hash
+- Pinned SGX Dockerfile base image by hash
+- Pinned firmware test package Dockerfile base image by hash
+- Pinned middleware's docker cython-hidapi package by commit hash
+- Removed self.expected overwriting from RawCommand test command
+- Using cls for class variable name in all class methods
+- Fixed unused import warnings
+- Removed unwanted comma from regexp in attestation verification
+- Made string concatenation explicit in lists
+- Added output buffer size validation in bip32_derive_private
+- Bumped aws-actions/configure-aws-credentials, github/codeql-action
+
 ## [5.4.0] - 27/01/2025
 
 ### Features/enhancements

--- a/firmware/src/ledger/ui/src/defs.h
+++ b/firmware/src/ledger/ui/src/defs.h
@@ -31,6 +31,6 @@
 // Version and patchlevel
 #define VERSION_MAJOR 0x05
 #define VERSION_MINOR 0x04
-#define VERSION_PATCH 0x00
+#define VERSION_PATCH 0x01
 
 #endif // __DEFS_H

--- a/firmware/src/ledger/ui/test/onboard/test_onboard.c
+++ b/firmware/src/ledger/ui/test/onboard/test_onboard.c
@@ -313,11 +313,11 @@ void test_is_onboarded() {
 
     G_device_onboarded = true;
     assert(5 == is_onboarded());
-    ASSERT_APDU("\x80\x01\x05\x04\x00");
+    ASSERT_APDU("\x80\x01\x05\x04\x01");
 
     G_device_onboarded = false;
     assert(5 == is_onboarded());
-    ASSERT_APDU("\x80\x00\x05\x04\x00");
+    ASSERT_APDU("\x80\x00\x05\x04\x01");
 }
 
 int main() {

--- a/firmware/src/powhsm/src/defs.h
+++ b/firmware/src/powhsm/src/defs.h
@@ -30,6 +30,6 @@
 // Version and patchlevel
 #define VERSION_MAJOR 0x05
 #define VERSION_MINOR 0x04
-#define VERSION_PATCH 0x00
+#define VERSION_PATCH 0x01
 
 #endif // __DEFS_H

--- a/middleware/ledger/protocol.py
+++ b/middleware/ledger/protocol.py
@@ -38,8 +38,8 @@ from comm.bitcoin import get_unsigned_tx, get_tx_hash
 
 class HSM2ProtocolLedger(HSM2Protocol):
     # Current manager supported versions for HSM UI and HSM SIGNER (<=)
-    UI_VERSION = HSM2FirmwareVersion(5, 4, 0)
-    APP_VERSION = HSM2FirmwareVersion(5, 4, 0)
+    UI_VERSION = HSM2FirmwareVersion(5, 4, 1)
+    APP_VERSION = HSM2FirmwareVersion(5, 4, 1)
 
     # Amount of time to wait to make sure the app is opened
     OPEN_APP_WAIT = 1  # second

--- a/middleware/tests/ledger/test_protocol.py
+++ b/middleware/tests/ledger/test_protocol.py
@@ -49,7 +49,7 @@ class TestHSM2ProtocolLedger(TestCase):
         self.dongle.disconnect = Mock()
         self.dongle.is_onboarded = Mock(return_value=True)
         self.dongle.get_current_mode = Mock(return_value=HSM2Dongle.MODE.SIGNER)
-        self.dongle.get_version = Mock(return_value=HSM2FirmwareVersion(5, 4, 0))
+        self.dongle.get_version = Mock(return_value=HSM2FirmwareVersion(5, 4, 1))
         self.dongle.get_signer_parameters = Mock(return_value=Mock(
             min_required_difficulty=123))
         self.protocol = HSM2ProtocolLedger(self.pin, self.dongle)

--- a/middleware/tests/ledger/test_protocol_v1.py
+++ b/middleware/tests/ledger/test_protocol_v1.py
@@ -47,7 +47,7 @@ class TestHSM1ProtocolLedger(TestCase):
         self.dongle.disconnect = Mock()
         self.dongle.is_onboarded = Mock(return_value=True)
         self.dongle.get_current_mode = Mock(return_value=HSM2Dongle.MODE.SIGNER)
-        self.dongle.get_version = Mock(return_value=HSM2FirmwareVersion(5, 4, 0))
+        self.dongle.get_version = Mock(return_value=HSM2FirmwareVersion(5, 4, 1))
         self.dongle.get_signer_parameters = Mock(return_value=Mock(
             min_required_difficulty=123))
         self.protocol = HSM1ProtocolLedger(self.pin, self.dongle)


### PR DESCRIPTION
- Bump version to 5.4.1
- Updated version references in firmware, middleware and unit tests
- Updated CHANGELOG
- Updated integration tests version being used for CI