### PR TITLE
Enhance Ledger setup script to explicitly remove Signer and UI apps

### DIFF
--- a/dist/ledger/scripts/setup
+++ b/dist/ledger/scripts/setup
@@ -94,6 +94,16 @@ function removeFidoApp() {
     error
 }
 
+function removeSignerApp() {
+    $LBUTILS delete --appName "RSK Sign" --targetId $TARGET_ID --rootPrivateKey $ROOTKEY > /dev/null 2> /dev/null
+    error
+}
+
+function removeUIApp() {
+    $LBUTILS delete --appName "UX" --targetId $TARGET_ID --rootPrivateKey $ROOTKEY > /dev/null 2> /dev/null
+    error
+}
+
 function promptRemoveAppWarning() {
     echo -e "\e[1;33mIf the Ledger prompts for 'Remove app' followed by the app name and identifier, then please accept it.\e[0m"
 }
@@ -180,6 +190,12 @@ removeEthereumApp
 echo -e "\e[1;32mRemoving the Fido App...\e[0m"
 promptRemoveAppWarning
 removeFidoApp
+echo -e "\e[1;32mRemoving the RSK Signer App...\e[0m"
+promptRemoveAppWarning
+removeSignerApp
+echo -e "\e[1;32mRemoving the RSK UI...\e[0m"
+promptRemoveAppWarning
+removeUIApp
 echo -e "\e[1;32mRemoving the existing certification authority (if any)...\e[0m"
 echo -e "\e[1;33mIf the Ledger prompts for 'Revoke certificate' followed by the certificate name and its public key, then please accept it.\e[0m"
 resetCA


### PR DESCRIPTION
This addresses an issue where the setup script would fail if the user has the signer and UI app already installed. To address this, we now explicitly delete both apps if they exist before proceeding with the onboard.