### PR TITLE
Updates ubuntu image on GH workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@ name: "Code coverage"
 
 on:
   push:
-    branches: [ "master", "feature/sgx" ]
+    branches: [ "master" ]
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ permissions: read-all
 jobs:
   coverage:
     name: Run tests and generate coverage reports
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout this repo

--- a/.github/workflows/lint-c.yml
+++ b/.github/workflows/lint-c.yml
@@ -8,7 +8,7 @@ permissions: read-all
 jobs:
   run-c-linter:
     name: Run C linter
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout this repo

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -8,7 +8,7 @@ permissions: read-all
 jobs:
   run-python-linter:
     name: Run Python linter
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout this repo

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ permissions: read-all
 jobs:
   run-unit-tests:
     name: Unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout this repo
@@ -52,7 +52,7 @@ jobs:
 
   run-integration-tests-tcpsigner:
     name: Integration tests for TCPSigner
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout rsk-powhsm repo
@@ -90,7 +90,7 @@ jobs:
 
   run-integration-tests-sgx:
     name: Integration tests for SGX simulator
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout rsk-powhsm repo

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,7 +10,7 @@ permissions: read-all
 jobs:
   static-analysis:
     name: Run ledger static analysis
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout this repo


### PR DESCRIPTION
GitHub will deprecate ubuntu-20.04 runners in April 2025. This commit updates the target image from all workflows to use ubuntu-latest instead.

Incidentally, removes `feature/sgx` target from the coverage workflow, since this branch is not used anymore