### PR TITLE
Updates ubuntu image on GH workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ permissions: read-all
 jobs:
   coverage:
     name: Run tests and generate coverage reports
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout this repo

--- a/.github/workflows/lint-c.yml
+++ b/.github/workflows/lint-c.yml
@@ -8,7 +8,7 @@ permissions: read-all
 jobs:
   run-c-linter:
     name: Run C linter
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout this repo

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -8,7 +8,7 @@ permissions: read-all
 jobs:
   run-python-linter:
     name: Run Python linter
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout this repo

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ permissions: read-all
 jobs:
   run-unit-tests:
     name: Unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout this repo
@@ -43,7 +43,7 @@ jobs:
 
   run-integration-tests:
     name: Integration tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout rsk-powhsm repo

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,7 +10,7 @@ permissions: read-all
 jobs:
   static-analysis:
     name: Run ledger static analysis
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout this repo


### PR DESCRIPTION
GitHub will deprecate ubuntu-20.04 runners on April 2025. This commit updates the target image from all workflows to use ubuntu-latest instead.