### PR TITLE
Adds development branches as targets for codeQL and coverage workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master", "develop-2.3", "develop-3.0" ]
+    branches: [ "master", "develop-5.2", "develop-5.4" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "develop-5.2", "develop-5.4" ]
   schedule:
     - cron: "39 5 * * 1"
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@ name: "Code coverage"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "develop-5.2", "develop-5.4" ]
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           aws s3 sync \
             middleware/coverage/ \
-            s3://${{ secrets.CODECOVERAGE_S3_BUCKET }}/powhsm_5.4.x/middleware_coverage_report \
+            s3://${{ secrets.CODECOVERAGE_S3_BUCKET }}/powhsm_head/middleware_coverage_report \
             --sse aws:kms --sse-kms-key-id ${{ secrets.CODECOVERAGE_KMS_KEY_ID }} \
             --no-progress --follow-symlinks --delete --only-show-errors
 
@@ -52,7 +52,7 @@ jobs:
         run: |
           aws s3 sync \
             firmware/coverage/output/ \
-            s3://${{ secrets.CODECOVERAGE_S3_BUCKET }}/powhsm_5.4.x/firmware_coverage_report \
+            s3://${{ secrets.CODECOVERAGE_S3_BUCKET }}/powhsm_head/firmware_coverage_report \
             --sse aws:kms --sse-kms-key-id ${{ secrets.CODECOVERAGE_KMS_KEY_ID }} \
             --no-progress --follow-symlinks --delete --only-show-errors
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ![Tests](https://github.com/rsksmart/rsk-powhsm/actions/workflows/run-tests.yml/badge.svg)
 ![Python linter](https://github.com/rsksmart/rsk-powhsm/actions/workflows/lint-python.yml/badge.svg)
 ![C linter](https://github.com/rsksmart/rsk-powhsm/actions/workflows/lint-c.yml/badge.svg)
-[![Middleware coverage](https://img.shields.io/endpoint?url=https://d16sboe9lzo4ru.cloudfront.net/powhsm_5.4.x/middleware_coverage_report/badge.json)](https://d16sboe9lzo4ru.cloudfront.net/powhsm_5.4.x/middleware_coverage_report/index.html)
-[![Firmware coverage](https://img.shields.io/endpoint?url=https://d16sboe9lzo4ru.cloudfront.net/powhsm_5.4.x/firmware_coverage_report/badge.json)](https://d16sboe9lzo4ru.cloudfront.net/powhsm_5.4.x/firmware_coverage_report/index.html)
+[![Middleware coverage](https://img.shields.io/endpoint?url=https://d16sboe9lzo4ru.cloudfront.net/powhsm_head/middleware_coverage_report/badge.json)](https://d16sboe9lzo4ru.cloudfront.net/powhsm_head/middleware_coverage_report/index.html)
+[![Firmware coverage](https://img.shields.io/endpoint?url=https://d16sboe9lzo4ru.cloudfront.net/powhsm_head/firmware_coverage_report/badge.json)](https://d16sboe9lzo4ru.cloudfront.net/powhsm_head/firmware_coverage_report/index.html)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 


### PR DESCRIPTION
- Adds develop-5.2 and develop-5.4 as targets for the codeQL and coverage workflows
- Renames remote destination for coverage reports to avoid conflicts with development branches