### PR TITLE
Remove development branch from codeQL and coverage workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master", "develop-5.2", "develop-5.4" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "master", "develop-5.2", "develop-5.4" ]
+    branches: [ "master" ]
   schedule:
     - cron: "39 5 * * 1"
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@ name: "Code coverage"
 
 on:
   push:
-    branches: [ "master", "develop-5.2", "develop-5.4" ]
+    branches: [ "master" ]
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
Having these on master branch has no practical effect. They will be added to the respective development branches