### PR TITLE
Automatically delete all pre-installed apps on Ledger before the onboard

### DIFF
--- a/dist/ledger/README-cli.md
+++ b/dist/ledger/README-cli.md
@@ -40,12 +40,11 @@ Press [Enter] to continue
 
 Pressing `Enter` will proceed with the installation. Pay attention to the instructions both on the terminal and on the device's screen, since a few confirmations are required.
 ```
-Removing the Bitcoin App...
+Removing the existing installed apps (if any)...
 The Ledger will prompt for 'Allow Unknown Manager'. Please accept it.
+Removing the UX App...
 If the Ledger prompts for 'Remove app' followed by the app name and identifier, then please accept it.
-Removing the Ethereum App...
-If the Ledger prompts for 'Remove app' followed by the app name and identifier, then please accept it.
-Removing the Fido App...
+Removing the RSK Sign App...
 If the Ledger prompts for 'Remove app' followed by the app name and identifier, then please accept it.
 Removing the existing certification authority (if any)...
 If the Ledger prompts for 'Revoke certificate' followed by the certificate name and its public key, then please accept it.
@@ -440,31 +439,29 @@ the steps below:
    displayed:
 
    ```
-   Removing the Bitcoin App...
+   Removing the existing installed apps (if any)...
    The Ledger will prompt for 'Allow Unknown Manager'. Please accept it.
-   If the Ledger prompts for 'Remove app' followed by the app name and identifier, then please accept it.
    ```
 
-   Press the Right button once to confirm access to the manager. If new messages
-   are displayed in the console, proceed to step 5. Otherwise, it means you need
-   to confirm the removal of the Bitcoin app. In this case, press the Right button
-   once more to confirm the removal.
+   Press the Right button once to confirm access to the manager.
 
 5. The next confirmations will depend on the apps that are currently installed on
-   the device. The script will guide you through the process. All the steps below
-   will be performed automatically if there's no action needed from the user. At any
-   point that the script stops and requests the user to Accept an action, just press
-   the Right button once to confirm:
+   the device. The script will guide you through the process. For each app that
+   is currently installed, the script will stop and display a message similar to
+   the ones below:
 
    ```
-   Removing the Ethereum App...
+   Removing the UX App...
    If the Ledger prompts for 'Remove app' followed by the app name and identifier, then please accept it.
-   Removing the Fido App...
+   Removing the RSK Sign App...
    If the Ledger prompts for 'Remove app' followed by the app name and identifier, then please accept it.
-   Removing the RSK Signer App...
-   If the Ledger prompts for 'Remove app' followed by the app name and identifier, then please accept it.
-   Removing the RSK UI...
-   If the Ledger prompts for 'Remove app' followed by the app name and identifier, then please accept it.
+   ```
+
+   Press the Right button once for each of the confirmations requested.
+
+   If no apps are currently installed, the following message is displayed and no confirmation is required:
+   ```
+   No apps to remove.
    ```
 
 6. Finally, the script will set up the RSK certification authority. The user will

--- a/dist/ledger/scripts/setup
+++ b/dist/ledger/scripts/setup
@@ -79,31 +79,6 @@ function checkForPinFile() {
     fi
 }
 
-function removeBitcoinApp() {
-    $LBUTILS delete --appName "Bitcoin" --targetId $TARGET_ID --rootPrivateKey $ROOTKEY > /dev/null 2> /dev/null
-    error
-}
-
-function removeEthereumApp() {
-    $LBUTILS delete --appName "Ethereum" --targetId $TARGET_ID --rootPrivateKey $ROOTKEY > /dev/null 2> /dev/null
-    error
-}
-
-function removeFidoApp() {
-    $LBUTILS delete --appName "Fido U2F" --targetId $TARGET_ID --rootPrivateKey $ROOTKEY > /dev/null 2> /dev/null
-    error
-}
-
-function removeSignerApp() {
-    $LBUTILS delete --appName "RSK Sign" --targetId $TARGET_ID --rootPrivateKey $ROOTKEY > /dev/null 2> /dev/null
-    error
-}
-
-function removeUIApp() {
-    $LBUTILS delete --appName "UX" --targetId $TARGET_ID --rootPrivateKey $ROOTKEY > /dev/null 2> /dev/null
-    error
-}
-
 function promptRemoveAppWarning() {
     echo -e "\e[1;33mIf the Ledger prompts for 'Remove app' followed by the app name and identifier, then please accept it.\e[0m"
 }
@@ -116,6 +91,22 @@ function setupCA() {
     $LBUTILS setupCA --public $RSK_CA --name "RSK" --targetId $TARGET_ID --rootPrivateKey $ROOTKEY > /dev/null 2> /dev/null
     error
 }
+
+function removeAllApps() {
+    APPS=$($LBUTILS listApps --targetId $TARGET_ID --rootPrivateKey $ROOTKEY --scp | grep 'Installed app' | sed 's/Installed app: //g')
+    if [ -z "$APPS" ]; then
+        echo -e "\e[1;32mNo apps to remove.\e[0m"
+        return
+    fi
+
+    echo "$APPS" | while IFS= read -r app; do
+        echo -e "\e[1;32mRemoving the $app App...\e[0m"
+        promptRemoveAppWarning
+        $LBUTILS delete --appName "$app" --targetId $TARGET_ID --rootPrivateKey $ROOTKEY > /dev/null 2> /dev/null
+        error
+    done
+}
+
 
 function installSigner() {
     ICON="$(cat $FIRMWARE_DIR/signer.icon.hex)"
@@ -179,23 +170,9 @@ echo -e "\e[1;33mConnect it while keeping the right button pressed until you see
 echo -e "\e[1;33mrelease the right button and wait until the menu appears.\e[0m"
 echo -e "Press [Enter] to continue"
 read continue
-echo
-echo -e "\e[1;32mRemoving the Bitcoin App...\e[0m"
+echo -e "\e[1;32mRemoving the existing installed apps (if any)...\e[0m"
 echo -e "\e[1;33mThe Ledger will prompt for 'Allow Unknown Manager'. Please accept it.\e[0m"
-promptRemoveAppWarning
-removeBitcoinApp
-echo -e "\e[1;32mRemoving the Ethereum App...\e[0m"
-promptRemoveAppWarning
-removeEthereumApp
-echo -e "\e[1;32mRemoving the Fido App...\e[0m"
-promptRemoveAppWarning
-removeFidoApp
-echo -e "\e[1;32mRemoving the RSK Signer App...\e[0m"
-promptRemoveAppWarning
-removeSignerApp
-echo -e "\e[1;32mRemoving the RSK UI...\e[0m"
-promptRemoveAppWarning
-removeUIApp
+removeAllApps
 echo -e "\e[1;32mRemoving the existing certification authority (if any)...\e[0m"
 echo -e "\e[1;33mIf the Ledger prompts for 'Revoke certificate' followed by the certificate name and its public key, then please accept it.\e[0m"
 resetCA

--- a/middleware/build/bld
+++ b/middleware/build/bld
@@ -7,7 +7,7 @@ fi
 
 HIDDENIMPORTS="--hiddenimport _cffi_backend"
 if [[ "$1" == "lbutils" ]]; then
-    HIDDENIMPORTS="--hiddenimport ledgerblue.loadApp --hiddenimport ledgerblue.deleteApp --hiddenimport ledgerblue.setupCustomCA --hiddenimport ledgerblue.resetCustomCA --hiddenimport ledgerblue.genCAPair"
+    HIDDENIMPORTS="--hiddenimport ledgerblue.loadApp --hiddenimport ledgerblue.deleteApp --hiddenimport ledgerblue.setupCustomCA --hiddenimport ledgerblue.resetCustomCA --hiddenimport ledgerblue.genCAPair --hiddenimport ledgerblue.listApps"
 fi
 
 # Main script name to build (no extension)

--- a/middleware/lbutils.py
+++ b/middleware/lbutils.py
@@ -32,6 +32,7 @@ def main():
         "setupCA": "setupCustomCA",
         "resetCA": "resetCustomCA",
         "genCA": "genCAPair",
+        "listApps": "listApps",
     }
 
     if len(sys.argv) < 2 or sys.argv[1] not in utilities:

--- a/middleware/tests/admin/test_lbutils.py
+++ b/middleware/tests/admin/test_lbutils.py
@@ -80,3 +80,49 @@ class TestLbutils(TestCase):
         self.assertEqual([call('ledgerblue.genCAPair', run_name='__main__')],
                          run_module.call_args_list)
         self.assertEqual(e.exception.code, 0)
+
+    def test_list_apps_no_apps(self, run_module):
+        def run_module_mock(module, run_name):
+            print("Generated random root public key : b'123456789'")
+            print("Using test master key b'123456789'")
+            print("Using ephemeral key b'987654321'")
+            print("Broken certificate chain - loading from user key")
+
+        run_module.side_effect = run_module_mock
+
+        with patch('sys.argv', ['lbutils.py', 'listApps']):
+            with patch('sys.stdout.write') as stdout_mock:
+                with self.assertRaises(SystemExit) as e:
+                    main()
+                self.assertEqual([call('No apps installed'), call('\n')],
+                                 stdout_mock.call_args_list)
+
+        self.assertTrue(run_module.called)
+        self.assertEqual([call('ledgerblue.listApps', run_name='__main__')],
+                         run_module.call_args_list)
+        self.assertEqual(e.exception.code, 0)
+
+    def test_list_apps_with_apps(self, run_module):
+        def run_module_mock(module, run_name):
+            print("Generated random root public key : b'123456789'")
+            print("Using test master key b'123456789'")
+            print("Using ephemeral key b'987654321'")
+            print("Broken certificate chain - loading from user key")
+            print("[{'name': 'first app name', 'flags': 1234, 'hash': '01020304'},"
+                  " {'name': 'second app name', 'flags': 1234, 'hash': '05060708'}]")
+
+        run_module.side_effect = run_module_mock
+
+        with patch('sys.argv', ['lbutils.py', 'listApps']):
+            with patch('sys.stdout.write') as stdout_mock:
+                with self.assertRaises(SystemExit) as e:
+                    main()
+                self.assertEqual([
+                    call('Installed app: first app name\nInstalled app: second app name'),
+                    call('\n')],
+                    stdout_mock.call_args_list)
+
+        self.assertTrue(run_module.called)
+        self.assertEqual([call('ledgerblue.listApps', run_name='__main__')],
+                         run_module.call_args_list)
+        self.assertEqual(e.exception.code, 0)


### PR DESCRIPTION
- Expose the `listApps` command on `lbutils`
- Adds a `post_process` optional function that parses the raw output of ledgerblue utility into a format we can easily use
- Enhances the `setup` script so that it automatically checks and deletes all pre-installed apps before proceeding with the onboard
- Adds unit tests to the new `listApps` utility
- Updates distribution documentation