### PR TITLE
Destination size check in der_encode_signature

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -90,7 +90,7 @@ jobs:
 
   run-integration-tests-sgx:
     name: Integration tests for SGX simulator
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout rsk-powhsm repo

--- a/firmware/src/hal/sgx/src/trusted/der_utils.c
+++ b/firmware/src/hal/sgx/src/trusted/der_utils.c
@@ -45,13 +45,19 @@ static size_t der_encode_uint(uint8_t* dest, uint8_t* src, size_t len) {
     return (size_t)dest[1] + 2;
 }
 
-uint8_t der_encode_signature(uint8_t* dest, sgx_ecdsa256_signature_t* sig) {
+uint8_t der_encode_signature(uint8_t* dest,
+                             size_t dest_size,
+                             sgx_ecdsa256_signature_t* sig) {
     // Temporary buffers for R and S with
     // space for TLV with potential leading zero
     uint8_t r_encoded[sizeof(sig->r) + 3];
     uint8_t s_encoded[sizeof(sig->r) + 3];
     uint8_t r_len = (uint8_t)der_encode_uint(r_encoded, sig->r, sizeof(sig->r));
     uint8_t s_len = (uint8_t)der_encode_uint(s_encoded, sig->s, sizeof(sig->s));
+
+    // Check for enough space in destination buffer
+    if (dest_size < (size_t)(r_len + s_len + 2))
+        return 0;
 
     // Start the sequence
     dest[0] = 0x30;                             // Sequence tag

--- a/firmware/src/hal/sgx/src/trusted/der_utils.h
+++ b/firmware/src/hal/sgx/src/trusted/der_utils.h
@@ -25,4 +25,15 @@
 #include <stdint.h>
 #include <openenclave/bits/sgx/sgxtypes.h>
 
-uint8_t der_encode_signature(uint8_t* dest, sgx_ecdsa256_signature_t* sig);
+/**
+ * DER-encode the given ecdsa256 signature
+ *
+ * @param dest      destination buffer
+ * @param dest_size destination buffer size
+ * @param sig       signature to encode
+ *
+ * @returns the signature length or ZERO upon error
+ */
+uint8_t der_encode_signature(uint8_t* dest,
+                             size_t dest_size,
+                             sgx_ecdsa256_signature_t* sig);

--- a/firmware/src/hal/sgx/src/trusted/endorsement.c
+++ b/firmware/src/hal/sgx/src/trusted/endorsement.c
@@ -243,7 +243,13 @@ bool endorsement_sign(uint8_t* msg,
     // Output signature in DER format
     sgx_ecdsa256_signature_t* sig =
         &G_endorsement_ctx.envelope.quote_auth_data->signature;
-    *signature_out_length = der_encode_signature(signature_out, sig);
+    *signature_out_length =
+        der_encode_signature(signature_out, *signature_out_length, sig);
+
+    if (*signature_out_length == 0) {
+        LOG("Error encoding envelope signature\n");
+        goto endorsement_sign_fail;
+    }
 
     return true;
 

--- a/firmware/src/hal/sgx/test/der_utils/test_der_utils.c
+++ b/firmware/src/hal/sgx/test/der_utils/test_der_utils.c
@@ -31,10 +31,17 @@ void test_der_encode(const sgx_ecdsa256_signature_t* sig,
                      const uint8_t* expected,
                      int expected_len) {
     uint8_t dest[72]; // Buffer large enough for DER-encoded signature
-    int len = der_encode_signature(dest, (sgx_ecdsa256_signature_t*)sig);
+    uint8_t small_dest[expected_len - 1];
+    int len = der_encode_signature(
+        dest, sizeof(dest), (sgx_ecdsa256_signature_t*)sig);
 
     assert(len == expected_len);
     assert(memcmp(dest, expected, expected_len) == 0);
+
+    // Test what happens if we pass in a buffer that's not big enough
+    assert(0 == der_encode_signature(small_dest,
+                                     sizeof(small_dest),
+                                     (sgx_ecdsa256_signature_t*)sig));
 }
 
 int main() {

--- a/firmware/src/hal/sgx/test/endorsement/mocks.c
+++ b/firmware/src/hal/sgx/test/endorsement/mocks.c
@@ -36,7 +36,10 @@ uint8_t mock_format_id[] = {11, 22, 33};
 uint8_t mock_format_settings[] = {44, 55, 66, 77};
 uint8_t mock_evidence[] = MOCK_EVIDENCE;
 
-uint8_t der_encode_signature(uint8_t* dest, sgx_ecdsa256_signature_t* sig) {
+uint8_t der_encode_signature(uint8_t* dest,
+                             size_t dest_size,
+                             sgx_ecdsa256_signature_t* sig) {
+    assert(dest_size >= sizeof(sig->r) + sizeof(sig->s));
     memcpy(dest, sig->r, sizeof(sig->r));
     memcpy(dest + sizeof(sig->r), sig->s, sizeof(sig->s));
     return sizeof(sig->r) + sizeof(sig->s);


### PR DESCRIPTION
- Added `dest_size` parameter to `der_encode_signature`
- Added `dest_size` validation in `der_encode_signature`
- Updated `der_encode_signature` usage in `endorsement` module
- Added test cases for `der_encode_signature` dest size validation