### PR TITLE
Enhances Ledger setup and upgrade script to use `tput` for specific colors in user-facing messages

### DIFF
--- a/dist/ledger/scripts/print_utils
+++ b/dist/ledger/scripts/print_utils
@@ -1,0 +1,17 @@
+#
+# Utility functions for standardizing terminal output across setup scripts
+# Note: this script is not meant to be executed directly, but sourced by
+#       other scripts
+#
+
+function print_info() {
+    echo -e "\e[1;32m$1\e[0m"
+}
+
+function print_warning() {
+    echo -e "\e[1;33m$1\e[0m"
+}
+
+function print_error() {
+    echo -e "\e[1;31m$1\e[0m"
+}

--- a/dist/ledger/scripts/print_utils
+++ b/dist/ledger/scripts/print_utils
@@ -4,10 +4,28 @@
 #       other scripts
 #
 
-txtred=$(tput setaf 1)    # Red
-txtgrn=$(tput setaf 2)    # Green
-txtylw=$(tput setaf 3)    # Yellow
-txtrst=$(tput sgr0)       # Text reset
+if command -v tput >/dev/null 2>&1; then
+    # tput is available, check if terminal supports colors
+    if [ -n "$TERM" ] && [ "$TERM" != "dumb" ] && tput colors >/dev/null 2>&1; then
+        # Terminal supports colors
+        txtred=$(tput setaf 1)    # Red
+        txtgrn=$(tput setaf 2)    # Green
+        txtylw=$(tput setaf 3)    # Yellow
+        txtrst=$(tput sgr0)       # Text reset
+    else
+        # Terminal does not support colors
+        txtred=""
+        txtgrn=""
+        txtylw=""
+        txtrst=""
+    fi
+else
+    # tput is not available
+    txtred=""
+    txtgrn=""
+    txtylw=""
+    txtrst=""
+fi
 
 function print_info() {
     echo "${txtgrn}$1${txtrst}"

--- a/dist/ledger/scripts/print_utils
+++ b/dist/ledger/scripts/print_utils
@@ -4,14 +4,19 @@
 #       other scripts
 #
 
+txtred=$(tput setaf 1)    # Red
+txtgrn=$(tput setaf 2)    # Green
+txtylw=$(tput setaf 3)    # Yellow
+txtrst=$(tput sgr0)       # Text reset
+
 function print_info() {
-    echo -e "\e[1;32m$1\e[0m"
+    echo "${txtgrn}$1${txtrst}"
 }
 
 function print_warning() {
-    echo -e "\e[1;33m$1\e[0m"
+    echo "${txtylw}$1${txtrst}"
 }
 
 function print_error() {
-    echo -e "\e[1;31m$1\e[0m"
+    echo "${txtred}$1${txtrst}"
 }

--- a/dist/ledger/scripts/setup
+++ b/dist/ledger/scripts/setup
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-pushd $(dirname $0)/.. > /dev/null
+SCRIPT_DIR=$(realpath $(dirname $0))
+pushd $SCRIPT_DIR/.. > /dev/null
 ROOT_DIR="$(pwd)"
 popd > /dev/null
+
+source $SCRIPT_DIR/print_utils
 
 # Firmware directory
 FIRMWARE_DIR=$ROOT_DIR/firmware
@@ -56,7 +59,7 @@ function checkFirmware() {
     FILES="$FIRMWARE_DIR/signer.hex $FIRMWARE_DIR/signer.icon.hex $FIRMWARE_DIR/ui.hex $FIRMWARE_DIR/ui.icon.hex $FIRMWARE_DIR/ui.hex.sig"
     for f in ${FILES}; do
         if [[ ! -e $f ]]; then
-            echo -e "\e[1;31m Firmware file '$(basename $f)' does not exist. \e[0m"
+            print_error "Firmware file '$(basename $f)' does not exist."
             cleanBinaries
             exit 1
         fi
@@ -65,7 +68,7 @@ function checkFirmware() {
 
 function error() {
     if [ $? -ne 0 ]; then
-        echo -e "\e[1;31m Error comunicating with the dongle. Please check connection and restart the process. \e[0m"
+        print_error "Error comunicating with the dongle. Please check connection and restart the process."
         cleanBinaries
         exit 1
     fi
@@ -73,14 +76,14 @@ function error() {
 
 function checkForPinFile() {
     if [[ -e $PIN_FILE ]]; then
-        echo -e "\e[1;31m Legacy pin file '$(basename $PIN_FILE)' found. Please backup and remove before continuing. \e[0m"
+        print_error "Legacy pin file '$(basename $PIN_FILE)' found. Please backup and remove before continuing."
         cleanBinaries
         exit 1
     fi
 }
 
 function promptRemoveAppWarning() {
-    echo -e "\e[1;33mIf the Ledger prompts for 'Remove app' followed by the app name and identifier, then please accept it.\e[0m"
+    print_warning "If the Ledger prompts for 'Remove app' followed by the app name and identifier, then please accept it."
 }
 
 function resetCA() {
@@ -96,12 +99,12 @@ function removeAllApps() {
     APPS=$($LBUTILS listApps --targetId $TARGET_ID --rootPrivateKey $ROOTKEY --scp)
     error
     if [ -z "$APPS" ]; then
-        echo -e "\e[1;32mNo apps to remove.\e[0m"
+        print_info "No apps to remove."
         return
     fi
 
     echo "$APPS" | while IFS= read -r app; do
-        echo -e "\e[1;32mRemoving the $app App...\e[0m"
+        print_info "Removing the $app App..."
         promptRemoveAppWarning
         $LBUTILS delete --appName "$app" --targetId $TARGET_ID --rootPrivateKey $ROOTKEY > /dev/null 2> /dev/null
         error
@@ -162,56 +165,56 @@ function verify_attestation() {
     error
 }
 
-echo -e "\e[1;32mWelcome to the Ledger Nano S powHSM Setup for RSK \e[0m"
+print_info "Welcome to the Ledger Nano S powHSM Setup for RSK"
 echo
 checkForPinFile
 checkFirmware
-echo -e "\e[1;33mConnect your ledger into recovery mode:\e[0m"
-echo -e "\e[1;33mConnect it while keeping the right button pressed until you see a Recovery message, then\e[0m"
-echo -e "\e[1;33mrelease the right button and wait until the menu appears.\e[0m"
+print_warning "Connect your ledger into recovery mode:"
+print_warning "Connect it while keeping the right button pressed until you see a Recovery message, then"
+print_warning "release the right button and wait until the menu appears."
 echo -e "Press [Enter] to continue"
 read continue
-echo -e "\e[1;32mRemoving the existing installed apps (if any)...\e[0m"
-echo -e "\e[1;33mThe Ledger will prompt for 'Allow Unknown Manager'. Please accept it.\e[0m"
+print_info "Removing the existing installed apps (if any)..."
+print_warning "The Ledger will prompt for 'Allow Unknown Manager'. Please accept it."
 removeAllApps
-echo -e "\e[1;32mRemoving the existing certification authority (if any)...\e[0m"
-echo -e "\e[1;33mIf the Ledger prompts for 'Revoke certificate' followed by the certificate name and its public key, then please accept it.\e[0m"
+print_info "Removing the existing certification authority (if any)..."
+print_warning "If the Ledger prompts for 'Revoke certificate' followed by the certificate name and its public key, then please accept it."
 resetCA
 echo
-echo -e "\e[1;32mSetting up the RSK certification authority...\e[0m"
-echo -e "\e[1;33mThe Ledger will prompt for 'Trust certificate' followed by the certificate name and its public key. Please accept it.\e[0m"
+print_info "Setting up the RSK certification authority..."
+print_warning "The Ledger will prompt for 'Trust certificate' followed by the certificate name and its public key. Please accept it."
 setupCA
 echo
-echo -e "\e[1;32mInstalling the RSK Signer App...\e[0m"
+print_info "Installing the RSK Signer App..."
 installSigner
-echo -e "\e[1;32mInstalling the RSK UI...\e[0m"
+print_info "Installing the RSK UI..."
 installUI
 echo
-echo -e "\e[1;33mApp installation complete. Please disconnect and reconnect the device.\e[0m"
-echo -e "\e[1;33mYou should see a white screen upon restart.\e[0m"
+print_warning "App installation complete. Please disconnect and reconnect the device."
+print_warning "You should see a white screen upon restart."
 echo -e "Press [Enter] to continue"
 read continue
 echo
-echo -e "\e[1;33mOnboarding the device... \e[0m"
+print_warning "Onboarding the device..."
 createOutputDir
 onboard
 echo
-echo -e "\e[1;33mOnboarding complete. Please disconnect and reconnect the device.\e[0m"
+print_warning "Onboarding complete. Please disconnect and reconnect the device."
 echo -e "Press [Enter] to continue"
 read continue
 sleep 2
 echo
-echo -e "\e[1;32mGathering attestation\e[0m"
+print_info "Gathering attestation"
 attestation
 echo
-echo -e "\e[1;32mGathering public keys\e[0m"
+print_info "Gathering public keys"
 keys
 echo
-echo -e "\e[1;32mVerifying attestation\e[0m"
+print_info "Verifying attestation"
 verify_attestation
 echo
-echo -e "\e[1;32mpowHSM Setup complete.\e[0m"
-echo -e "\e[1;33mPlease disconnect the device.\e[0m"
+print_info "powHSM Setup complete."
+print_warning "Please disconnect the device."
 echo
 cleanBinaries
 exit 0

--- a/dist/ledger/scripts/upgrade-existing
+++ b/dist/ledger/scripts/upgrade-existing
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-pushd $(dirname $0)/.. > /dev/null
+SCRIPT_DIR=$(realpath $(dirname $0))
+pushd $SCRIPT_DIR/.. > /dev/null
 ROOT_DIR="$(pwd)"
 popd > /dev/null
+
+source $SCRIPT_DIR/print_utils
 
 TARGET_ID="$(cat $ROOT_DIR/scripts/target.id)"
 
@@ -46,7 +49,7 @@ ATTESTATION_FILE="$EXPORT_DIR/attestation.json"
 
 function error() {
     if [ $? -ne 0 ]; then
-        echo -e "\e[1;31m Error comunicating with the dongle. Please check that dongle is onboarded, check connection and restart the process. \e[0m"
+        print_error "Error comunicating with the dongle. Please check that dongle is onboarded, check connection and restart the process."
         cleanBinaries
         exit 1
     fi
@@ -54,7 +57,7 @@ function error() {
 
 function checkForPinFile() {
     if [[ ! -e $PIN_FILE ]]; then
-        echo -e "\e[1;31m Pin file '$(basename $PIN_FILE)' not found. \e[0m"
+        print_error "Pin file '$(basename $PIN_FILE)' not found."
         cleanBinaries
         exit 1
     fi
@@ -62,7 +65,7 @@ function checkForPinFile() {
 
 function checkForSignerAuthFile() {
     if [[ ! -e $SIGNER_AUTH_FILE ]]; then
-        echo -e "\e[1;31m Signer authorization file '$(basename $SIGNER_AUTH_FILE)' not found. \e[0m"
+        print_error "Signer authorization file '$(basename $SIGNER_AUTH_FILE)' not found."
         cleanBinaries
         exit 1
     fi
@@ -70,7 +73,7 @@ function checkForSignerAuthFile() {
 
 function checkForAttestationFile() {
     if [[ ! -e $DEVICE_ATTESTATION_FILE ]]; then
-        echo -e "\e[1;31m Attestation file '$(basename $DEVICE_ATTESTATION_FILE)' not found. \e[0m"
+        print_error "Attestation file '$(basename $DEVICE_ATTESTATION_FILE)' not found."
         cleanBinaries
         exit 1
     fi
@@ -81,7 +84,7 @@ function checkFirmware() {
     FILES="$FIRMWARE_DIR/signer.hex $FIRMWARE_DIR/signer.icon.hex"
     for f in ${FILES}; do
         if [[ ! -e $f ]]; then
-            echo -e "\e[1;31m Firmware file '$(basename $f)' does not exist. \e[0m"
+            print_error "Firmware file '$(basename $f)' does not exist."
             cleanBinaries
             exit 1
         fi
@@ -134,46 +137,46 @@ function verify_attestation() {
     error
 }
 
-echo -e "\e[1;32mWelcome to the Ledger Nano S powHSM Upgrade for RSK \e[0m"
-echo -e "\e[1;32mPlease make sure your HSM is onboarded before continuing with the firmware upgrade.\e[0m"
+print_info "Welcome to the Ledger Nano S powHSM Upgrade for RSK"
+print_info "Please make sure your HSM is onboarded before continuing with the firmware upgrade."
 echo
 checkFirmware
 checkForPinFile
 checkForSignerAuthFile
 checkForAttestationFile
 
-echo -e "\e[1;33mConnect your ledger.\e[0m"
+print_warning "Connect your ledger."
 echo -e "Press [Enter] to continue"
 read continue
 sleep 2
 echo
-echo -e "\e[1;32mAuthorising the new RSK Signer App...\e[0m"
+print_info "Authorising the new RSK Signer App..."
 authorizeSigner
 unlockToMenu
 sleep 2
 echo
-echo -e "\e[1;32mRemoving the old RSK Signer App...\e[0m"
+print_info "Removing the old RSK Signer App..."
 removeSigner
-echo -e "\e[1;32mInstalling the new RSK Signer App...\e[0m"
+print_info "Installing the new RSK Signer App..."
 installSigner
 echo
-echo -e "\e[1;33mApp upgrade complete. Please disconnect and reconnect the device.\e[0m"
+print_warning "App upgrade complete. Please disconnect and reconnect the device."
 echo -e "Press [Enter] to continue"
 read continue
 sleep 2
 createOutputDir
 echo
-echo -e "\e[1;32mGathering attestation\e[0m"
+print_info "Gathering attestation"
 attestation
 echo
-echo -e "\e[1;32mGathering public keys\e[0m"
+print_info "Gathering public keys"
 keys
 echo
-echo -e "\e[1;32mVerifying attestation\e[0m"
+print_info "Verifying attestation"
 verify_attestation
 echo
-echo -e "\e[1;32mpowHSM Upgrade complete.\e[0m"
-echo -e "\e[1;33mPlease disconnect the device.\e[0m"
+print_info "powHSM Upgrade complete."
+print_warning "Please disconnect the device."
 echo
 cleanBinaries
 exit 0


### PR DESCRIPTION
- Leverages `tput` utility to set message colors instead of using ANSI escape codes explicitly
- Adds fallback logic so that the script doesn't attempt to set colors if the terminal doesn't support this feature

See details on each individual commit message 