### PR TITLE
Version 5.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [5.4.2] - 07/03/2025
+
+### Features/enhancements
+
+- Updated ubuntu image on GH workflows due to planned defunct
+- Added 5.4.x development branch to code coverage, static analysis, and codeQL workflows
+- Added destination size check in der_encode_signature
+- Removed unnecessary use of OE verifier module for endorsement generation
+
+### Fixes
+
+- Fixed potential buffer overflow in der_encode_uint
+- Fixed SGX reproducibility builds by moving oeedger8r generated sources to their own directory
+- Minor C linting configuration fixes
+
 ## [5.4.1] - 07/02/2025
 
 ### Features/enhancements

--- a/firmware/src/ledger/ui/src/defs.h
+++ b/firmware/src/ledger/ui/src/defs.h
@@ -31,6 +31,6 @@
 // Version and patchlevel
 #define VERSION_MAJOR 0x05
 #define VERSION_MINOR 0x04
-#define VERSION_PATCH 0x01
+#define VERSION_PATCH 0x02
 
 #endif // __DEFS_H

--- a/firmware/src/ledger/ui/test/onboard/test_onboard.c
+++ b/firmware/src/ledger/ui/test/onboard/test_onboard.c
@@ -313,11 +313,11 @@ void test_is_onboarded() {
 
     G_device_onboarded = true;
     assert(5 == is_onboarded());
-    ASSERT_APDU("\x80\x01\x05\x04\x01");
+    ASSERT_APDU("\x80\x01\x05\x04\x02");
 
     G_device_onboarded = false;
     assert(5 == is_onboarded());
-    ASSERT_APDU("\x80\x00\x05\x04\x01");
+    ASSERT_APDU("\x80\x00\x05\x04\x02");
 }
 
 int main() {

--- a/firmware/src/powhsm/src/defs.h
+++ b/firmware/src/powhsm/src/defs.h
@@ -30,6 +30,6 @@
 // Version and patchlevel
 #define VERSION_MAJOR 0x05
 #define VERSION_MINOR 0x04
-#define VERSION_PATCH 0x01
+#define VERSION_PATCH 0x02
 
 #endif // __DEFS_H

--- a/middleware/ledger/protocol.py
+++ b/middleware/ledger/protocol.py
@@ -38,8 +38,8 @@ from comm.bitcoin import get_unsigned_tx, get_tx_hash
 
 class HSM2ProtocolLedger(HSM2Protocol):
     # Current manager supported versions for HSM UI and HSM SIGNER (<=)
-    UI_VERSION = HSM2FirmwareVersion(5, 4, 1)
-    APP_VERSION = HSM2FirmwareVersion(5, 4, 1)
+    UI_VERSION = HSM2FirmwareVersion(5, 4, 2)
+    APP_VERSION = HSM2FirmwareVersion(5, 4, 2)
 
     # Amount of time to wait to make sure the app is opened
     OPEN_APP_WAIT = 1  # second

--- a/middleware/tests/ledger/test_protocol.py
+++ b/middleware/tests/ledger/test_protocol.py
@@ -49,7 +49,7 @@ class TestHSM2ProtocolLedger(TestCase):
         self.dongle.disconnect = Mock()
         self.dongle.is_onboarded = Mock(return_value=True)
         self.dongle.get_current_mode = Mock(return_value=HSM2Dongle.MODE.SIGNER)
-        self.dongle.get_version = Mock(return_value=HSM2FirmwareVersion(5, 4, 1))
+        self.dongle.get_version = Mock(return_value=HSM2FirmwareVersion(5, 4, 2))
         self.dongle.get_signer_parameters = Mock(return_value=Mock(
             min_required_difficulty=123))
         self.protocol = HSM2ProtocolLedger(self.pin, self.dongle)

--- a/middleware/tests/ledger/test_protocol_v1.py
+++ b/middleware/tests/ledger/test_protocol_v1.py
@@ -47,7 +47,7 @@ class TestHSM1ProtocolLedger(TestCase):
         self.dongle.disconnect = Mock()
         self.dongle.is_onboarded = Mock(return_value=True)
         self.dongle.get_current_mode = Mock(return_value=HSM2Dongle.MODE.SIGNER)
-        self.dongle.get_version = Mock(return_value=HSM2FirmwareVersion(5, 4, 1))
+        self.dongle.get_version = Mock(return_value=HSM2FirmwareVersion(5, 4, 2))
         self.dongle.get_signer_parameters = Mock(return_value=Mock(
             min_required_difficulty=123))
         self.protocol = HSM1ProtocolLedger(self.pin, self.dongle)


### PR DESCRIPTION
- Bump version to 5.4.2
- Updated version references in firmware, middleware and unit tests
- Updated CHANGELOG