### PR TITLE
SGX upgrade workflow

### DIFF
--- a/firmware/src/powhsm/src/hsm.h
+++ b/firmware/src/powhsm/src/hsm.h
@@ -43,6 +43,12 @@ typedef struct {
     if (!seed_available())  \
         THROW(ERR_DEVICE_NOT_ONBOARDED);
 
+// Macro that throws an error if
+// the device is onboarded
+#define REQUIRE_NOT_ONBOARDED() \
+    if (seed_available())  \
+        THROW(ERR_DEVICE_ONBOARDED);
+
 // Macro that throws an error unless
 // the device is unlocked
 #define REQUIRE_UNLOCKED()  \

--- a/firmware/src/sgx/src/trusted/system.c
+++ b/firmware/src/sgx/src/trusted/system.c
@@ -18,6 +18,7 @@
 #include "bc_state.h"
 #include "err.h"
 #include "bc_err.h"
+#include "upgrade.h"
 
 /**
  * APDU buffer (host pointer and local enclave copy)
@@ -149,6 +150,9 @@ static external_processor_result_t system_do_process_apdu(unsigned int rx) {
         REQUIRE_UNLOCKED();
         result.tx = do_change_password(rx);
         break;
+    case SGX_UPGRADE:
+        result.tx = do_upgrade(rx);
+        break;
     case INS_HEARTBEAT:
         // For now, we don't support heartbeat in SGX
         THROW(ERR_INS_NOT_SUPPORTED);
@@ -242,6 +246,8 @@ bool system_init(unsigned char* msg_buffer, size_t msg_buffer_size) {
         LOG("Error loading nvmem\n");
         return false;
     }
+
+    upgrade_init();
 
     LOG("Modules initialized\n");
 

--- a/firmware/src/sgx/src/trusted/upgrade.c
+++ b/firmware/src/sgx/src/trusted/upgrade.c
@@ -1,0 +1,217 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 RSK Labs Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <string.h>
+
+#include "upgrade.h"
+#include "hal/exceptions.h"
+#include "hal/log.h"
+#include "hal/seed.h"
+#include "defs.h"
+#include "apdu.h"
+#include "hsm.h"
+
+// Operation selectors
+typedef enum {
+    OP_UPGRADE_START_EXPORT = 0x01,
+    OP_UPGRADE_START_IMPORT = 0x02,
+    OP_UPGRADE_IDENTIFY_PEER = 0x03,
+    OP_UPGRADE_PROCESS_DATA = 0x04,
+} op_code_upgrade_t;
+
+// Error codes
+typedef enum {
+    ERR_UPGRADE_PROTOCOL = 0x6A00,
+    ERR_UPGRADE_SPEC = 0x6A01,
+    ERR_UPGRADE_AUTH = 0x6A02,
+    ERR_UPGRADE_DATA_PROCESSING = 0x6A03,
+    ERR_UPGRADE_INTERNAL = 0x6A99,
+} err_code_upgrade_t;
+
+// MRENCLAVE size
+#define UPGRADE_MRENCLAVE_SIZE HASH_LENGTH
+
+// SGX upgrade spec
+typedef struct {
+    uint8_t mrenclave_from[UPGRADE_MRENCLAVE_SIZE];
+    uint8_t mrenclave_to[UPGRADE_MRENCLAVE_SIZE];
+} upgrade_spec_t;
+
+// SGX upgrade operations
+typedef enum {
+    upgrade_operation_none = 0,
+    upgrade_operation_export = 1,
+    upgrade_operation_import = 2,
+} upgrade_operation_t;
+
+// SGX upgrade SM states
+typedef enum {
+    upgrade_state_await_spec = 0,
+    upgrade_state_await_peer_id = 1,
+    upgrade_state_ready_for_xchg = 2,
+} upgrade_state_t;
+
+// SGX upgrade context
+typedef struct {
+    upgrade_operation_t operation;
+    upgrade_state_t state;
+    upgrade_spec_t spec;
+} upgrade_ctx_t;
+
+// SGX upgrade ctx
+static upgrade_ctx_t upgrade_ctx;
+
+/*
+ * Reset the upgrade context
+ */
+static void reset_upgrade() {
+    explicit_bzero(&upgrade_ctx, sizeof(upgrade_ctx));
+}
+
+/*
+ * Check that the context for the SGX upgrade
+ * matches the expected state and is in a
+ * consistent state.
+ *
+ * Reset the state and throw a protocol error
+ * otherwise.
+ */
+static void check_state(upgrade_state_t expected) {
+    // Consistency check
+    if (upgrade_ctx.state == upgrade_state_await_spec &&
+        upgrade_ctx.operation != upgrade_operation_none) {
+        reset_upgrade();
+        THROW(ERR_UPGRADE_PROTOCOL);
+    } else if (upgrade_ctx.state != upgrade_state_await_spec &&
+               upgrade_ctx.operation == upgrade_operation_none) {
+        reset_upgrade();
+        THROW(ERR_UPGRADE_PROTOCOL);
+    }
+    // Expectation check
+    if (upgrade_ctx.state != expected) {
+        reset_upgrade();
+        THROW(ERR_UPGRADE_PROTOCOL);
+    }
+}
+
+// -----------------------------------------------------------------------
+// Protocol implementation
+// -----------------------------------------------------------------------
+
+void upgrade_init() {
+    reset_upgrade();
+    LOG("Upgrade module initialized\n");
+}
+
+#define DUMMY_PEER_ID "peer-id:"
+#define DUMMY_PEER_ID_LEN (sizeof(DUMMY_PEER_ID) - 1)
+
+#define DUMMY_DATA "data_export_result"
+#define DUMMY_DATA_LEN (sizeof("data_export_result") - 1)
+
+unsigned int do_upgrade(volatile unsigned int rx) {
+    uint8_t* expected_mre = NULL;
+
+    switch (APDU_OP()) {
+    case OP_UPGRADE_START_EXPORT:
+    case OP_UPGRADE_START_IMPORT:
+        check_state(upgrade_state_await_spec);
+        if (APDU_OP() == OP_UPGRADE_START_EXPORT) {
+            // Exporting requirements
+            REQUIRE_ONBOARDED();
+            REQUIRE_UNLOCKED();
+        } else {
+            // Importing requirements
+            REQUIRE_NOT_ONBOARDED();
+        }
+        // We expect a from/to upgrade spec
+        if (APDU_DATA_SIZE(rx) != UPGRADE_MRENCLAVE_SIZE * 2) {
+            reset_upgrade();
+            THROW(ERR_UPGRADE_SPEC);
+        }
+        memcpy(upgrade_ctx.spec.mrenclave_from,
+               APDU_DATA_PTR,
+               UPGRADE_MRENCLAVE_SIZE);
+        memcpy(upgrade_ctx.spec.mrenclave_to,
+               APDU_DATA_PTR + UPGRADE_MRENCLAVE_SIZE,
+               UPGRADE_MRENCLAVE_SIZE);
+        LOG("Spec received\n");
+        LOG_HEX(
+            "From:", upgrade_ctx.spec.mrenclave_from, UPGRADE_MRENCLAVE_SIZE);
+        LOG_HEX("To:", upgrade_ctx.spec.mrenclave_to, UPGRADE_MRENCLAVE_SIZE);
+        upgrade_ctx.state = upgrade_state_await_peer_id;
+        upgrade_ctx.operation = APDU_OP() == OP_UPGRADE_START_EXPORT
+                                    ? upgrade_operation_export
+                                    : upgrade_operation_import;
+        LOG("Role: %s\n",
+            upgrade_ctx.operation == upgrade_operation_export ? "exporter"
+                                                              : "importer");
+        return TX_NO_DATA();
+    case OP_UPGRADE_IDENTIFY_PEER:
+        check_state(upgrade_state_await_peer_id);
+        expected_mre = upgrade_ctx.operation == upgrade_operation_export
+                           ? upgrade_ctx.spec.mrenclave_to
+                           : upgrade_ctx.spec.mrenclave_from;
+        if (APDU_DATA_SIZE(rx) != DUMMY_PEER_ID_LEN + UPGRADE_MRENCLAVE_SIZE ||
+            memcmp(APDU_DATA_PTR, DUMMY_PEER_ID, DUMMY_PEER_ID_LEN) ||
+            memcmp(APDU_DATA_PTR + DUMMY_PEER_ID_LEN,
+                   expected_mre,
+                   UPGRADE_MRENCLAVE_SIZE)) {
+            reset_upgrade();
+            THROW(ERR_UPGRADE_AUTH);
+        }
+        upgrade_ctx.state = upgrade_state_ready_for_xchg;
+        return TX_NO_DATA();
+    case OP_UPGRADE_PROCESS_DATA:
+        check_state(upgrade_state_ready_for_xchg);
+        switch (upgrade_ctx.operation) {
+        case upgrade_operation_export:
+            memcpy(APDU_DATA_PTR, DUMMY_DATA, DUMMY_DATA_LEN);
+            LOG("Data export complete\n");
+            reset_upgrade();
+            return TX_FOR_DATA_SIZE(DUMMY_DATA_LEN);
+        case upgrade_operation_import:
+            if (APDU_DATA_SIZE(rx) != DUMMY_DATA_LEN) {
+                reset_upgrade();
+                THROW(ERR_UPGRADE_DATA_PROCESSING);
+            }
+            LOG("Importing data\n");
+            LOG_HEX("From:",
+                    upgrade_ctx.spec.mrenclave_from,
+                    UPGRADE_MRENCLAVE_SIZE);
+            LOG_HEX(
+                "To:", upgrade_ctx.spec.mrenclave_to, UPGRADE_MRENCLAVE_SIZE);
+            LOG_HEX("Imported data:", APDU_DATA_PTR, APDU_DATA_SIZE(rx));
+            reset_upgrade();
+            return TX_NO_DATA();
+        default:
+            // We should never reach this point
+            THROW(ERR_UPGRADE_INTERNAL);
+        }
+    default:
+        reset_upgrade();
+        THROW(ERR_UPGRADE_PROTOCOL);
+        break;
+    }
+}

--- a/firmware/src/sgx/src/trusted/upgrade.h
+++ b/firmware/src/sgx/src/trusted/upgrade.h
@@ -22,44 +22,26 @@
  * IN THE SOFTWARE.
  */
 
-#ifndef __INSTRUCTIONS_H
-#define __INSTRUCTIONS_H
+#ifndef __TRUSTED_UPGRADE_H
+#define __TRUSTED_UPGRADE_H
+
+#include <stdint.h>
+
+// -----------------------------------------------------------------------
+// SGX upgrade authorization & migration
+// -----------------------------------------------------------------------
 
 /*
- * All APDU instructions
+ * Initialize the upgrade module
  */
+void upgrade_init();
 
-typedef enum {
-    // Signing-related
-    INS_SIGN = 0x02,
-    INS_GET_PUBLIC_KEY = 0x04,
+/*
+ * Implement the upgrade protocol.
+ *
+ * @arg[in] rx    number of received bytes from the host
+ * @ret           number of transmited bytes to the host
+ */
+unsigned int do_upgrade(volatile unsigned int rx);
 
-    // Misc
-    RSK_IS_ONBOARD = 0x06,
-    RSK_MODE_CMD = 0x43,
-
-    // Advance blockchain and blockchain state
-    INS_ADVANCE = 0x10,
-    INS_ADVANCE_PARAMS = 0x11,
-    INS_GET_STATE = 0x20,
-    INS_RESET_STATE = 0x21,
-    INS_UPD_ANCESTOR = 0x30,
-
-    // Attestation
-    INS_ATTESTATION = 0x50,
-    INS_HEARTBEAT = 0x60,
-
-    // Exit
-    INS_EXIT = 0xff,
-
-    // SGX-only (don't hurt to have them all here)
-    SGX_ONBOARD = 0xA0,
-    SGX_IS_LOCKED = 0xA1,
-    SGX_RETRIES = 0xA2,
-    SGX_UNLOCK = 0xA3,
-    SGX_ECHO = 0xA4,
-    SGX_CHANGE_PASSWORD = 0xA5,
-    SGX_UPGRADE = 0xA6,
-} apdu_instruction_t;
-
-#endif // __INSTRUCTIONS_H
+#endif // __TRUSTED_UPGRADE_H

--- a/firmware/src/sgx/test/run-all.sh
+++ b/firmware/src/sgx/test/run-all.sh
@@ -2,7 +2,7 @@
 
 if [[ $1 == "exec" ]]; then
     BASEDIR=$(realpath $(dirname $0))
-    TESTDIRS="system keyvalue_store"
+    TESTDIRS="upgrade system keyvalue_store"
     for d in $TESTDIRS; do
         echo "******************************"
         echo "Testing $d..."

--- a/firmware/src/sgx/test/upgrade/Makefile
+++ b/firmware/src/sgx/test/upgrade/Makefile
@@ -1,0 +1,38 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021 RSK Labs Ltd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+include ../common/common.mk
+
+PROG = test.out
+OBJS = upgrade.o log.o test_upgrade.o
+
+all: $(PROG)
+
+$(PROG): $(OBJS)
+	$(CC) $(COVFLAGS) -o $@ $^
+
+.PHONY: clean test
+clean:
+	rm -f $(PROG) *.o $(COVFILES)
+
+test: all
+	./$(PROG)

--- a/firmware/src/sgx/test/upgrade/test_upgrade.c
+++ b/firmware/src/sgx/test/upgrade/test_upgrade.c
@@ -1,0 +1,364 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 RSK Labs Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+
+#include "upgrade.h"
+
+#include "hal/exceptions.h"
+#include "apdu_utils.h"
+
+#define SRC_MRE                                \
+    "\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA" \
+    "\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA" \
+    "\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA" \
+    "\xAA\xAA"
+
+#define DST_MRE                                \
+    "\xBB\xBB\xBB\xBB\xBB\xBB\xBB\xBB\xBB\xBB" \
+    "\xBB\xBB\xBB\xBB\xBB\xBB\xBB\xBB\xBB\xBB" \
+    "\xBB\xBB\xBB\xBB\xBB\xBB\xBB\xBB\xBB\xBB" \
+    "\xBB\xBB"
+
+// Globals
+static try_context_t G_try_last_open_context_var;
+try_context_t* G_try_last_open_context = &G_try_last_open_context_var;
+unsigned char G_io_apdu_buffer[IO_APDU_BUFFER_SIZE];
+
+// Testing helpers
+#define ASSERT_DOESNT_THROW(st)             \
+    {                                       \
+        BEGIN_TRY {                         \
+            TRY{st} CATCH_OTHER(e) {        \
+                printf("Expected no "       \
+                       "exception but got " \
+                       "0x%x\n",            \
+                       e);                  \
+                assert(false);              \
+            }                               \
+            FINALLY {                       \
+            }                               \
+        }                                   \
+        END_TRY;                            \
+    }
+
+#define ASSERT_THROWS(st, ex)               \
+    {                                       \
+        BEGIN_TRY {                         \
+            TRY {                           \
+                { st; }                     \
+                printf("Expected a 0x%x "   \
+                       "exception but "     \
+                       "none was thrown\n", \
+                       ex);                 \
+                assert(false);              \
+            }                               \
+            CATCH_OTHER(e) {                \
+                if (e != ex) {              \
+                    printf("Expected a "    \
+                           "0x%x exception" \
+                           " but got 0x%x " \
+                           "instead\n",     \
+                           ex,              \
+                           e);              \
+                    assert(false);          \
+                }                           \
+            }                               \
+            FINALLY {                       \
+            }                               \
+        }                                   \
+        END_TRY;                            \
+    }
+
+// Mocks
+struct {
+    bool seed_available;
+    bool access_is_locked;
+} G_mocks;
+
+unsigned char* communication_get_msg_buffer() {
+    return G_io_apdu_buffer;
+}
+
+bool seed_available() {
+    return G_mocks.seed_available;
+}
+
+bool access_is_locked() {
+    return G_mocks.access_is_locked;
+}
+
+// Unit tests
+void setup() {
+    upgrade_init();
+    explicit_bzero(&G_mocks, sizeof(G_mocks));
+}
+
+// Exporting
+void test_do_upgrade_export_ok() {
+    unsigned int rx;
+
+    setup();
+    printf("Test exporting...\n");
+
+    G_mocks.seed_available = true;
+    G_mocks.access_is_locked = false;
+
+    ASSERT_DOESNT_THROW({
+        // Start export
+        SET_APDU("\x80\xA6\x01" SRC_MRE DST_MRE, rx);
+        assert(3 == do_upgrade(rx));
+        // Identify peer
+        SET_APDU("\x80\xA6\x03"
+                 "peer-id:" DST_MRE,
+                 rx);
+        assert(3 == do_upgrade(rx));
+        // Process data
+        SET_APDU("\x80\xA6\x04", rx);
+        assert(3 + sizeof("data_export_result") - 1 == do_upgrade(rx));
+        ASSERT_APDU("\x80\xA6\x04"
+                    "data_export_result");
+    });
+}
+
+void test_do_upgrade_export_not_onboarded() {
+    unsigned int rx;
+
+    setup();
+    printf("Test exporting when not onboarded...\n");
+
+    G_mocks.seed_available = false;
+
+    ASSERT_THROWS(
+        {
+            // Start export
+            SET_APDU("\x80\xA6\x01" SRC_MRE DST_MRE, rx);
+            do_upgrade(rx);
+        },
+        0x6BEE);
+}
+
+void test_do_upgrade_export_not_unlocked() {
+    unsigned int rx;
+
+    setup();
+    printf("Test exporting when not unlocked...\n");
+
+    G_mocks.seed_available = true;
+    G_mocks.access_is_locked = true;
+
+    ASSERT_THROWS(
+        {
+            // Start export
+            SET_APDU("\x80\xA6\x01" SRC_MRE DST_MRE, rx);
+            do_upgrade(rx);
+        },
+        0x6BF1);
+}
+
+void test_do_upgrade_export_invalid_spec() {
+    unsigned int rx;
+
+    setup();
+    printf("Test exporting when invalid spec given...\n");
+
+    G_mocks.seed_available = true;
+    G_mocks.access_is_locked = false;
+
+    ASSERT_THROWS(
+        {
+            // Start export
+            SET_APDU("\x80\xA6\x01"
+                     "not a valid spec",
+                     rx);
+            do_upgrade(rx);
+        },
+        0x6A01);
+}
+
+void test_do_upgrade_export_invalid_peer_id() {
+    unsigned int rx;
+
+    setup();
+    printf("Test exporting when invalid peer id given...\n");
+
+    G_mocks.seed_available = true;
+    G_mocks.access_is_locked = false;
+
+    ASSERT_THROWS(
+        {
+            // Start export
+            SET_APDU("\x80\xA6\x01" SRC_MRE DST_MRE, rx);
+            assert(3 == do_upgrade(rx));
+            SET_APDU("\x80\xA6\x03"
+                     "invalid peer id",
+                     rx);
+            do_upgrade(rx);
+        },
+        0x6A02);
+}
+
+// Importing
+void test_do_upgrade_import_ok() {
+    unsigned int rx;
+
+    setup();
+    printf("Test importing...\n");
+
+    G_mocks.seed_available = false;
+
+    ASSERT_DOESNT_THROW({
+        // Start import
+        SET_APDU("\x80\xA6\x02" SRC_MRE DST_MRE, rx);
+        assert(3 == do_upgrade(rx));
+        // Identify peer
+        SET_APDU("\x80\xA6\x03"
+                 "peer-id:" SRC_MRE,
+                 rx);
+        assert(3 == do_upgrade(rx));
+        // Process data
+        SET_APDU("\x80\xA6\x04"
+                 "doto_import_result",
+                 rx);
+        assert(3 == do_upgrade(rx));
+    });
+}
+
+void test_do_upgrade_import_onboarded() {
+    unsigned int rx;
+
+    setup();
+    printf("Test importing when onboarded...\n");
+
+    G_mocks.seed_available = true;
+
+    ASSERT_THROWS(
+        {
+            // Start export
+            SET_APDU("\x80\xA6\x02" SRC_MRE DST_MRE, rx);
+            do_upgrade(rx);
+        },
+        0x6BEF);
+}
+
+void test_do_upgrade_import_invalid_spec() {
+    unsigned int rx;
+
+    setup();
+    printf("Test importing when invalid spec given...\n");
+
+    G_mocks.seed_available = false;
+
+    ASSERT_THROWS(
+        {
+            // Start export
+            SET_APDU("\x80\xA6\x02"
+                     "not a valid spec",
+                     rx);
+            do_upgrade(rx);
+        },
+        0x6A01);
+}
+
+void test_do_upgrade_import_invalid_peer_id() {
+    unsigned int rx;
+
+    setup();
+    printf("Test importing when invalid peer id given...\n");
+
+    G_mocks.seed_available = false;
+
+    ASSERT_THROWS(
+        {
+            // Start import
+            SET_APDU("\x80\xA6\x02" SRC_MRE DST_MRE, rx);
+            assert(3 == do_upgrade(rx));
+            SET_APDU("\x80\xA6\x03"
+                     "invalid peer id",
+                     rx);
+            do_upgrade(rx);
+        },
+        0x6A02);
+}
+
+void test_do_upgrade_import_invalid_data() {
+    unsigned int rx;
+
+    setup();
+    printf("Test importing when invalid data given...\n");
+
+    G_mocks.seed_available = false;
+
+    ASSERT_THROWS(
+        {
+            // Start import
+            SET_APDU("\x80\xA6\x02" SRC_MRE DST_MRE, rx);
+            assert(3 == do_upgrade(rx));
+            SET_APDU("\x80\xA6\x03"
+                     "peer-id:" SRC_MRE,
+                     rx);
+            assert(3 == do_upgrade(rx));
+            SET_APDU("\x80\xA6\x04"
+                     "invalid data",
+                     rx);
+            do_upgrade(rx);
+        },
+        0x6A03);
+}
+
+void test_do_upgrade_invalid_op() {
+    unsigned int rx;
+
+    setup();
+    printf("Test when feeding invalid OP...\n");
+
+    G_mocks.seed_available = false;
+
+    ASSERT_THROWS(
+        {
+            // Start import
+            SET_APDU("\x80\xA6\xAB", rx);
+            do_upgrade(rx);
+        },
+        0x6A00);
+}
+
+int main() {
+    test_do_upgrade_export_ok();
+    test_do_upgrade_export_not_onboarded();
+    test_do_upgrade_export_not_unlocked();
+    test_do_upgrade_export_invalid_spec();
+    test_do_upgrade_export_invalid_peer_id();
+
+    test_do_upgrade_import_ok();
+    test_do_upgrade_import_onboarded();
+    test_do_upgrade_import_invalid_spec();
+    test_do_upgrade_import_invalid_peer_id();
+    test_do_upgrade_import_invalid_data();
+
+    test_do_upgrade_invalid_op();
+
+    return 0;
+}


### PR DESCRIPTION
- Added new instruction on trusted system module for upgrades
- Added upgrade module that handles upgrade instruction (export & import)
- Added upgrade module initialisation upon system initialisation
- Basic mock upgrade workflow implementation
- Added helper REQUIRE_NOT_ONBOARDED macro
- Added upgrade operation init and APDU processing unit tests on system unit tests
- Added upgrade module unit tests
- Fixed failing unit tests