### PR TITLE
SGX DB migration

### DIFF
--- a/firmware/src/hal/include/hal/access.h
+++ b/firmware/src/hal/include/hal/access.h
@@ -88,6 +88,17 @@ bool access_wipe();
  */
 bool access_set_password(char* password, uint8_t password_length);
 
+/**
+ * @brief Writes the password to the given buffer
+ *
+ * @param out               output buffer
+ * @param out_size [in/out] output buffer size
+ *
+ * @return whether the output succeeded
+ */
+bool access_output_password_USE_FROM_EXPORT_ONLY(uint8_t* out,
+                                                 size_t* out_size);
+
 #endif
 // END of platform-dependent code
 

--- a/firmware/src/hal/include/hal/seed.h
+++ b/firmware/src/hal/include/hal/seed.h
@@ -142,6 +142,26 @@ bool seed_wipe();
  */
 bool seed_generate(uint8_t* client_seed, uint8_t client_seed_size);
 
+/**
+ * @brief Writes the seed to the given buffer
+ *
+ * @param out               output buffer
+ * @param out_size [in/out] output buffer size
+ *
+ * @return whether the output succeeded
+ */
+bool seed_output_USE_FROM_EXPORT_ONLY(uint8_t* out, size_t* out_size);
+
+/**
+ * @brief Sets the seed from the given buffer
+ *
+ * @param in        input buffer
+ * @param in_size   input buffer size
+ *
+ * @return whether the setting of the seed succeeded
+ */
+bool seed_set_USE_FROM_EXPORT_ONLY(uint8_t* in, size_t in_size);
+
 #endif
 // END of platform-dependent code
 

--- a/firmware/src/hal/sgx/test/mock/openenclave/common.h
+++ b/firmware/src/hal/sgx/test/mock/openenclave/common.h
@@ -27,6 +27,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 // Taken from OpenEnclave's include/openenclave/bits/defs.h
 
@@ -230,5 +231,9 @@ oe_result_t oe_get_evidence(const oe_uuid_t* format_id,
 oe_result_t oe_free_evidence(uint8_t* evidence_buffer);
 
 oe_result_t oe_attester_shutdown(void);
+
+// Taken from OpenEnclave's include/openenclave/enclave.h
+
+bool oe_is_within_enclave(const void* ptr, size_t size);
 
 #endif // #ifndef __MOCK_OE_COMMON_H

--- a/firmware/src/hal/sgx/test/mock/openenclave/enclave.h
+++ b/firmware/src/hal/sgx/test/mock/openenclave/enclave.h
@@ -1,0 +1,1 @@
+common.h

--- a/firmware/src/sgx/src/trusted/migrate.c
+++ b/firmware/src/sgx/src/trusted/migrate.c
@@ -1,0 +1,106 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 RSK Labs Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "migrate.h"
+
+#include <string.h>
+#include "hal/seed.h"
+#include "hal/access.h"
+#include "hal/log.h"
+#include "pin_policy.h"
+#include "defs.h"
+
+#define EXPORT_SIZE (SEED_LENGTH + MAX_PIN_LENGTH)
+
+bool migrate_export(uint8_t* out, size_t* out_size) {
+    bool retval = false;
+
+    // Sizes check
+    if (*out_size < EXPORT_SIZE) {
+        LOG("Migration export error: output buffer too small\n");
+        goto migrate_export_exit;
+    }
+
+    // Export
+    explicit_bzero(out, *out_size);
+    uint8_t* tmp = out;
+    size_t tmp_size = *out_size;
+    size_t exp_size = 0;
+    if (!seed_output_USE_FROM_EXPORT_ONLY(out, &tmp_size)) {
+        LOG("Migration export error: unable to export seed\n");
+        goto migrate_export_exit;
+    }
+    tmp += tmp_size;
+    exp_size += tmp_size;
+    tmp_size = *out_size - tmp_size;
+    if (!access_output_password_USE_FROM_EXPORT_ONLY(tmp, &tmp_size)) {
+        LOG("Migration export error: unable to export password\n");
+        goto migrate_export_exit;
+    }
+    exp_size += tmp_size;
+    if (exp_size != EXPORT_SIZE) {
+        LOG("Migration export error: unexpected exported size\n");
+        goto migrate_export_exit;
+    }
+
+    *out_size = EXPORT_SIZE;
+    retval = true;
+    LOG("Migration exported DB\n");
+
+migrate_export_exit:
+    return retval;
+}
+
+bool migrate_import(uint8_t* in, size_t in_size) {
+    bool retval = false;
+
+    // Sizes check
+    if (in_size < EXPORT_SIZE) {
+        LOG("Migration import error: input buffer too small\n");
+        goto migrate_import_exit;
+    }
+
+    // Import
+    if (!seed_set_USE_FROM_EXPORT_ONLY(in, SEED_LENGTH)) {
+        LOG("Migration import error: unable to import seed\n");
+        goto migrate_import_exit;
+    }
+    if (!access_set_password((char*)(in + SEED_LENGTH),
+                             in_size - SEED_LENGTH)) {
+        LOG("Migration import error: unable to import password\n");
+        goto migrate_import_exit;
+    }
+
+    explicit_bzero(in, in_size);
+    retval = true;
+    LOG("Migration imported DB\n");
+
+migrate_import_exit:
+    // Wipe everything in case something fails
+    if (!retval) {
+        seed_wipe();
+        access_wipe();
+    }
+    return retval;
+}

--- a/firmware/src/sgx/src/trusted/migrate.h
+++ b/firmware/src/sgx/src/trusted/migrate.h
@@ -1,0 +1,52 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 RSK Labs Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef __TRUSTED_MIGRATE_H
+#define __TRUSTED_MIGRATE_H
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * @brief Exports the DB
+ *
+ * @param out output buffer
+ * @param out_size [in/out] output buffer size
+ *
+ * @returns whether export succeeded
+ */
+bool migrate_export(uint8_t* out, size_t* out_size);
+
+/**
+ * @brief Imports the given DB to the local store
+ *
+ * @param in input buffer
+ * @param in_size input buffer size
+ *
+ * @returns whether the import succeeded
+ */
+bool migrate_import(uint8_t* in, size_t in_size);
+
+#endif // __TRUSTED_MIGRATE_H

--- a/firmware/src/sgx/test/migrate/Makefile
+++ b/firmware/src/sgx/test/migrate/Makefile
@@ -1,0 +1,38 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021 RSK Labs Ltd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+include ../common/common.mk
+
+PROG = test.out
+OBJS = migrate.o test_migrate.o
+
+all: $(PROG)
+
+$(PROG): $(OBJS)
+	$(CC) $(COVFLAGS) -o $@ $^
+
+.PHONY: clean test
+clean:
+	rm -f $(PROG) *.o $(COVFILES)
+
+test: all
+	./$(PROG)

--- a/firmware/src/sgx/test/migrate/test_migrate.c
+++ b/firmware/src/sgx/test/migrate/test_migrate.c
@@ -1,0 +1,230 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 RSK Labs Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+#include <assert.h>
+
+#include "migrate.h"
+
+// Mocks
+struct {
+    bool seed_wipe;
+    bool seed_output_USE_FROM_EXPORT_ONLY;
+    bool seed_set_USE_FROM_EXPORT_ONLY;
+    bool access_set_password;
+    bool access_wipe;
+    bool access_output_password_USE_FROM_EXPORT_ONLY;
+    bool inconsistent_mocks;
+} G_mocks;
+
+struct {
+    bool seed_wipe;
+    bool access_wipe;
+} G_called;
+
+bool seed_wipe() {
+    G_called.seed_wipe = true;
+    return G_mocks.seed_wipe;
+}
+
+bool seed_output_USE_FROM_EXPORT_ONLY(uint8_t* out, size_t* out_size) {
+    if (G_mocks.inconsistent_mocks) {
+        *out_size = 31;
+        return true;
+    }
+    memcpy(out, "01234567890123456789012345678901", 32);
+    *out_size = 32;
+    return G_mocks.seed_output_USE_FROM_EXPORT_ONLY;
+}
+
+bool seed_set_USE_FROM_EXPORT_ONLY(uint8_t* in, size_t in_size) {
+    if (!G_mocks.seed_set_USE_FROM_EXPORT_ONLY)
+        return false;
+    assert(!memcmp(in, "abcdefabcdefabcdefabcdef12345678", in_size));
+    return true;
+}
+
+bool access_set_password(char* password, uint8_t password_length) {
+    if (!G_mocks.access_set_password)
+        return false;
+    assert(!memcmp(password, "ABCDEF12", password_length));
+    return true;
+}
+
+bool access_wipe() {
+    G_called.access_wipe = true;
+    return G_mocks.access_wipe;
+}
+
+bool access_output_password_USE_FROM_EXPORT_ONLY(uint8_t* out,
+                                                 size_t* out_size) {
+    if (G_mocks.inconsistent_mocks) {
+        *out_size = 7;
+        return true;
+    }
+    memcpy(out, "abcABC89", 8);
+    *out_size = 8;
+    return G_mocks.access_output_password_USE_FROM_EXPORT_ONLY;
+}
+
+// Test output buffer and size
+#define IMPORT_EXPORT_SIZE 40 // Seed + max pasword length
+uint8_t G_out[IMPORT_EXPORT_SIZE];
+size_t G_out_size;
+
+// Test input buffer
+uint8_t G_in[IMPORT_EXPORT_SIZE];
+
+// Unit tests
+void setup() {
+    explicit_bzero(&G_mocks, sizeof(G_mocks));
+    explicit_bzero(&G_called, sizeof(G_called));
+    memcpy(
+        G_in, "abcdefabcdefabcdefabcdef12345678ABCDEF12", IMPORT_EXPORT_SIZE);
+}
+
+// Exporting
+void test_migrate_export_ok() {
+    setup();
+    printf("Test exporting...\n");
+
+    G_mocks.seed_output_USE_FROM_EXPORT_ONLY = true;
+    G_mocks.access_output_password_USE_FROM_EXPORT_ONLY = true;
+
+    G_out_size = sizeof(G_out);
+    assert(migrate_export(G_out, &G_out_size));
+    assert(!memcmp(
+        G_out, "01234567890123456789012345678901abcABC89", sizeof(G_out)));
+}
+
+void test_migrate_export_err_buftoosmall() {
+    setup();
+    printf("Test exporting when the output buffer is too small...\n");
+
+    G_mocks.seed_output_USE_FROM_EXPORT_ONLY = true;
+    G_mocks.access_output_password_USE_FROM_EXPORT_ONLY = true;
+
+    uint8_t out[IMPORT_EXPORT_SIZE - 1];
+    G_out_size = sizeof(out);
+    assert(!migrate_export(out, &G_out_size));
+}
+
+void test_migrate_export_err_seed() {
+    setup();
+    printf("Test exporting when exporting the seed fails...\n");
+
+    G_mocks.seed_output_USE_FROM_EXPORT_ONLY = false;
+    G_mocks.access_output_password_USE_FROM_EXPORT_ONLY = true;
+
+    G_out_size = sizeof(G_out);
+    assert(!migrate_export(G_out, &G_out_size));
+}
+
+void test_migrate_export_err_access() {
+    setup();
+    printf("Test exporting when exporting the password fails...\n");
+
+    G_mocks.seed_output_USE_FROM_EXPORT_ONLY = true;
+    G_mocks.access_output_password_USE_FROM_EXPORT_ONLY = false;
+
+    G_out_size = sizeof(G_out);
+    assert(!migrate_export(G_out, &G_out_size));
+}
+
+void test_migrate_export_err_inconsistency() {
+    setup();
+    printf("Test exporting when there is an inconsistency in "
+           "the exported values from other modules...\n");
+
+    G_mocks.inconsistent_mocks = true;
+
+    G_out_size = sizeof(G_out);
+    assert(!migrate_export(G_out, &G_out_size));
+}
+
+// Importing
+void test_migrate_import_ok() {
+    setup();
+    printf("Test importing...\n");
+
+    G_mocks.seed_set_USE_FROM_EXPORT_ONLY = true;
+    G_mocks.access_set_password = true;
+
+    assert(migrate_import(G_in, strlen((char*)G_in)));
+    assert(!G_called.access_wipe);
+    assert(!G_called.seed_wipe);
+}
+
+void test_migrate_import_err_buftoosmall() {
+    setup();
+    printf("Test importing when input buffer is too small...\n");
+
+    G_mocks.seed_set_USE_FROM_EXPORT_ONLY = true;
+    G_mocks.access_set_password = true;
+
+    assert(!migrate_import(G_in, strlen((char*)G_in) - 1));
+    assert(G_called.access_wipe);
+    assert(G_called.seed_wipe);
+}
+
+void test_migrate_import_err_seed() {
+    setup();
+    printf("Test importing when seed importing fails...\n");
+
+    G_mocks.seed_set_USE_FROM_EXPORT_ONLY = false;
+    G_mocks.access_set_password = true;
+
+    assert(!migrate_import(G_in, strlen((char*)G_in)));
+    assert(G_called.access_wipe);
+    assert(G_called.seed_wipe);
+}
+
+void test_migrate_import_err_access() {
+    setup();
+    printf("Test importing when password importing fails...\n");
+
+    G_mocks.seed_set_USE_FROM_EXPORT_ONLY = true;
+    G_mocks.access_set_password = false;
+
+    assert(!migrate_import(G_in, strlen((char*)G_in)));
+    assert(G_called.access_wipe);
+    assert(G_called.seed_wipe);
+}
+
+int main() {
+    test_migrate_export_ok();
+    test_migrate_export_err_buftoosmall();
+    test_migrate_export_err_seed();
+    test_migrate_export_err_access();
+    test_migrate_export_err_inconsistency();
+
+    test_migrate_import_ok();
+    test_migrate_import_err_buftoosmall();
+    test_migrate_import_err_seed();
+    test_migrate_import_err_access();
+
+    return 0;
+}

--- a/firmware/src/sgx/test/run-all.sh
+++ b/firmware/src/sgx/test/run-all.sh
@@ -2,7 +2,7 @@
 
 if [[ $1 == "exec" ]]; then
     BASEDIR=$(realpath $(dirname $0))
-    TESTDIRS="upgrade system keyvalue_store"
+    TESTDIRS="keyvalue_store migrate upgrade system"
     for d in $TESTDIRS; do
         echo "******************************"
         echo "Testing $d..."


### PR DESCRIPTION
- New migrate module with functions to export/import seed and password
- Import/export on the upgrade module now uses the migrate module functions
- Added seed export/import functions to the seed module
- Added export function to the access module
- Added migrate module unit tests
- Added unit tests for new seed module exporting/importing functions
- Updated upgrade module unit tests to account for migrate module use
- Fixed failing unit tests