### PR TITLE
SGX upgrade peer authentication

### DIFF
--- a/firmware/src/hal/sgx/src/trusted/endorsement.c
+++ b/firmware/src/hal/sgx/src/trusted/endorsement.c
@@ -179,7 +179,12 @@ bool endorsement_sign(uint8_t* msg,
                        sizeof(G_endorsement_ctx.envelope));
     }
 
-    if (!evidence_generate(ENDORSEMENT_FORMAT,
+    evidence_format_t format = {
+        .id = ENDORSEMENT_FORMAT,
+        .settings = NULL,
+        .settings_size = 0,
+    };
+    if (!evidence_generate(&format,
                            msg,
                            msg_size,
                            &G_endorsement_ctx.envelope.raw,

--- a/firmware/src/hal/sgx/src/trusted/evidence.h
+++ b/firmware/src/hal/sgx/src/trusted/evidence.h
@@ -35,6 +35,17 @@
 #define EVIDENCE_FORMAT_SGX_LOCAL \
     ((oe_uuid_t){OE_FORMAT_UUID_SGX_LOCAL_ATTESTATION})
 
+typedef struct {
+    // The format ID.
+    // See openenclave/attestation/sgx/evidence.h for supported formats.
+    oe_uuid_t id;
+    // The format settings buffer for the corresponding format id.
+    // This is returned by oe_verifier_get_format_settings.
+    uint8_t* settings;
+    // The size of the format settings buffer.
+    size_t settings_size;
+} evidence_format_t;
+
 /**
  * @brief Initializes the evidence module
  *
@@ -48,9 +59,19 @@ bool evidence_init();
 void evidence_finalise();
 
 /**
- * @brief Tells whether a given evidence format is supported
+ * Get the format settings for the given format id
  *
- * @param format_id the format to query for support
+ * @param format [in/out] the format. should only have id set (rest to ZEROES)
+ *
+ * @returns whether the format settings were gathered successfully
+ */
+bool evidence_get_format_settings(evidence_format_t* format);
+
+/**
+ * Tells whether a given format is supported for
+ * evidence generation and verification
+ *
+ * @param format_id the format id
  *
  * @returns whether the format is supported
  */
@@ -60,7 +81,7 @@ bool evidence_supports_format(oe_uuid_t format_id);
  * @brief Generates evidence with the
  * given format id and custom claims
  *
- * @param format_id_bs          evidence format id
+ * @param format                evidence format to use
  * @param ccs                   custom claims buffer
  * @param ccs_size              custom claims buffer size
  * @param evidence_buffer       [out] evidence buffer pointer
@@ -68,7 +89,7 @@ bool evidence_supports_format(oe_uuid_t format_id);
  *
  * @returns true iff evidence was successfully generated
  */
-bool evidence_generate(oe_uuid_t format_id,
+bool evidence_generate(evidence_format_t* format,
                        uint8_t* ccs,
                        size_t ccs_size,
                        uint8_t** evidence_buffer,

--- a/firmware/src/hal/sgx/test/endorsement/test_endorsement.c
+++ b/firmware/src/hal/sgx/test/endorsement/test_endorsement.c
@@ -74,7 +74,7 @@ bool evidence_supports_format(oe_uuid_t format_id) {
     return G_mocks.evidence_supports_format;
 }
 
-bool evidence_generate(oe_uuid_t format_id,
+bool evidence_generate(evidence_format_t* format,
                        uint8_t* ccs,
                        size_t ccs_size,
                        uint8_t** evidence_buffer,
@@ -82,7 +82,8 @@ bool evidence_generate(oe_uuid_t format_id,
     G_called.evidence_generate = true;
 
     const oe_uuid_t expected_format_id = EVIDENCE_FORMAT_SGX_ECDSA;
-    assert(!memcmp(&expected_format_id, &format_id, sizeof(format_id)));
+    assert(!memcmp(&expected_format_id, &format->id, sizeof(format->id)));
+    assert(!format->settings && !format->settings_size);
     assert(ccs && ccs_size);
     assert(evidence_buffer && evidence_buffer_size);
     assert(!*evidence_buffer);


### PR DESCRIPTION
- Added evidence sending and receiving to upgrade module
- Added peer evidence validation to upgrade module
- Evidence module can now receive the desired format settings to be used for evidence generation
- Additional format settings getter for evidence module
- Added missing function documentation in evidence module
- Added self and peer id unit tests to upgrade module unit tests
- Added `evidence_get_format_settings` unit test cases
- Fixed failing unit tests