### PR TITLE
Add SGX migration authorization tool

### DIFF
--- a/build-dist-sgx
+++ b/build-dist-sgx
@@ -63,6 +63,13 @@ echo
 echo "$HSM_DIR/hsmsgx_enclave.signed"
 echo "$ENCLAVE_HASH"
 
+MIGRATION_AUTH_FILE="migration_auth.json"
+EXPORTER_HASH="0000000000000000000000000000000000000000000000000000000000000000"
+IMPORTER_HASH=$(echo $ENCLAVE_HASH | grep -oP 'mrenclave: \K[0-9a-f]+')
+echo -e "\e[33mCreating empty migration authorization for upgrades...\e[0m"
+$ROOT_DIR/docker/mware/do-notty-nousb /hsm2 "python middleware/signmigration.py message -e $EXPORTER_HASH -i $IMPORTER_HASH -o $MIGRATION_AUTH_FILE" > /dev/null
+mv -f $ROOT_DIR/$MIGRATION_AUTH_FILE $HSM_DIR/$MIGRATION_AUTH_FILE
+
 echo
 echo -e "\e[32mBuild complete.\e[0m"
 

--- a/build-dist-sgx
+++ b/build-dist-sgx
@@ -44,6 +44,7 @@ echo -e "\e[33mBuilding middleware...\e[0m"
 $ROOT_DIR/middleware/build/dist_sgx
 cp $ROOT_DIR/middleware/bin/adm_sgx.tgz $BIN_DIR
 cp $ROOT_DIR/middleware/bin/manager_sgx.tgz $BIN_DIR
+cp $ROOT_DIR/middleware/bin/signmigration.tgz $BIN_DIR
 echo
 
 echo -e "\e[33mBuilding SGX apps...\e[0m"

--- a/middleware/admin/sgx_migration_authorization.py
+++ b/middleware/admin/sgx_migration_authorization.py
@@ -1,0 +1,132 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021 RSK Labs Ltd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import json
+import secp256k1 as ec
+from .utils import is_hex_string_of_length, normalize_hex_string, keccak_256
+from .ledger_utils import encode_eth_message
+
+
+class SGXMigrationAuthorization:
+    VERSION = 1  # Only supported version
+
+    @staticmethod
+    def from_jsonfile(path):
+        try:
+            with open(path, "r") as file:
+                spec_auth_map = json.loads(file.read())
+
+            if type(spec_auth_map) != dict:
+                raise ValueError(
+                    "JSON file must contain an object as a top level element")
+            if spec_auth_map["version"] != SGXMigrationAuthorization.VERSION:
+                raise ValueError("Unsupported file format version "
+                                 f"{spec_auth_map['version']}")
+
+            migration_spec = SGXMigrationSpec(spec_auth_map["hashes"])
+            signatures = spec_auth_map["signatures"]
+            return SGXMigrationAuthorization(migration_spec, signatures)
+        except (ValueError, json.JSONDecodeError) as e:
+            raise ValueError("Unable to read SGX Migration Authorization from "
+                             f"{path}: {str(e)}")
+
+    @staticmethod
+    def for_spec(migration_spec):
+        return SGXMigrationAuthorization(migration_spec, [])
+
+    def __init__(self, migration_spec, signatures):
+        self._migration_spec = migration_spec
+        self._signatures = signatures[:]
+
+        if type(self._migration_spec) != SGXMigrationSpec:
+            raise ValueError(f"Invalid migration spec given: {migration_spec}")
+
+        if type(signatures) != list:
+            raise ValueError("Signatures must be a list")
+
+        for signature in signatures:
+            self._assert_signature_valid(signature)
+
+    @property
+    def migration_spec(self):
+        return self._migration_spec
+
+    @property
+    def signatures(self):
+        return self._signatures[:]
+
+    def add_signature(self, signature):
+        self._assert_signature_valid(signature)
+        self._signatures.append(signature)
+
+    def to_dict(self):
+        return {
+            "version": self.VERSION,
+            "hashes": self._migration_spec.to_dict(),
+            "signatures": self._signatures[:],
+        }
+
+    def save_to_jsonfile(self, path):
+        with open(path, "w") as file:
+            file.write(json.dumps(self.to_dict(), indent=2))
+
+    def _assert_signature_valid(self, signature):
+        try:
+            ec.PrivateKey().ecdsa_deserialize(bytes.fromhex(signature))
+        except Exception as e:
+            raise ValueError(f"Invalid DER signature: {signature}: {e}")
+
+
+class SGXMigrationSpec:
+    def __init__(self, hashes):
+        if type(hashes) != dict:
+            raise ValueError("Hashes must be a dict")
+        if not is_hex_string_of_length(hashes["exporter"], 32, allow_prefix=True):
+            raise ValueError("Exporter hash must be a 32-byte hex string")
+        if not is_hex_string_of_length(hashes["importer"], 32, allow_prefix=True):
+            raise ValueError("Importer hash must be a 32-byte hex string")
+        self._exporter_hash = normalize_hex_string(hashes["exporter"])
+        self._importer_hash = normalize_hex_string(hashes["importer"])
+
+    @property
+    def exporter(self):
+        return self._exporter_hash
+
+    @property
+    def importer(self):
+        return self._importer_hash
+
+    @property
+    def msg(self):
+        return f"RSK_powHSM_SGX_upgrade_from_{self.exporter}_to_{self.importer}"
+
+    def get_authorization_msg(self):
+        return encode_eth_message(self.msg)
+
+    def get_authorization_digest(self):
+        return keccak_256(self.get_authorization_msg())
+
+    def to_dict(self):
+        return {
+            "exporter": self.exporter,
+            "importer": self.importer,
+        }

--- a/middleware/build/all
+++ b/middleware/build/all
@@ -12,4 +12,5 @@ QUIET=1 $BUILDDIR/adm_ledger && \
 QUIET=1 $BUILDDIR/adm_sgx && \
 QUIET=1 $BUILDDIR/lbutils && \
 QUIET=1 $BUILDDIR/signapp && \
+QUIET=1 $BUILDDIR/signmigration && \
 echo "" && sha256sum $BINDIR/*.tgz

--- a/middleware/build/dist_sgx
+++ b/middleware/build/dist_sgx
@@ -7,6 +7,8 @@ echo "Building SGX distribution binaries..."
 
 QUIET=1 $BUILDDIR/manager_sgx && \
 QUIET=1 $BUILDDIR/adm_sgx && \
+QUIET=1 $BUILDDIR/signmigration && \
 echo "" && \
 sha256sum $BINDIR/manager_sgx.tgz && \
-sha256sum $BINDIR/adm_sgx.tgz
+sha256sum $BINDIR/adm_sgx.tgz && \
+sha256sum $BINDIR/signmigration.tgz

--- a/middleware/build/signmigration
+++ b/middleware/build/signmigration
@@ -1,0 +1,2 @@
+#!/bin/bash
+source $(dirname $0)/bld-docker signmigration

--- a/middleware/signapp.py
+++ b/middleware/signapp.py
@@ -23,7 +23,6 @@
 import sys
 from os.path import isfile
 from argparse import ArgumentParser
-import logging
 import ecdsa
 from admin.misc import (
     get_eth_dongle,
@@ -47,8 +46,6 @@ OP_SIGN_MSG_HASH = bytes.fromhex("800000")
 
 
 def main():
-    logging.disable(logging.CRITICAL)
-
     parser = ArgumentParser(description="powHSM Signer Authorization Generator")
     parser.add_argument("operation", choices=["hash", "message", "key", "eth", "manual"])
     parser.add_argument(

--- a/middleware/signmigration.py
+++ b/middleware/signmigration.py
@@ -1,0 +1,246 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021 RSK Labs Ltd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import sys
+from os.path import isfile
+from argparse import ArgumentParser
+import ecdsa
+import logging
+from admin.misc import (
+    get_eth_dongle,
+    dispose_eth_dongle,
+    info,
+    AdminError
+)
+from comm.utils import is_hex_string_of_length
+from comm.bip32 import BIP32Path
+from admin.sgx_migration_authorization import SGXMigrationAuthorization, SGXMigrationSpec
+from admin.ledger_utils import eth_message_to_printable
+
+# Default signing path
+DEFAULT_ETH_PATH = "m/44'/60'/0'/0/0"
+
+
+def _require_output_path(options, require_existing=False):
+    if options.output_path is None:
+        raise AdminError("Must provide an output path (-o/--output)")
+    if require_existing and not isfile(options.output_path):
+        raise AdminError(f"Invalid output path: {options.output_path}")
+
+
+def do_message(options):
+    if options.exporter_hash is None:
+        raise AdminError("Must provide an exporter hash (-e/--exporter)")
+    if options.importer_hash is None:
+        raise AdminError("Must provide an importer hash (-i/--importer)")
+
+    info("Computing the SGX migration authorization message...")
+    migration_spec = SGXMigrationSpec({
+        "exporter": options.exporter_hash,
+        "importer": options.importer_hash
+    })
+    sgx_authorization = SGXMigrationAuthorization.for_spec(migration_spec)
+    if options.output_path is None:
+        info(eth_message_to_printable(migration_spec.get_authorization_msg()))
+    else:
+        sgx_authorization.save_to_jsonfile(options.output_path)
+        info(f"SGX migration authorization saved to {options.output_path}")
+
+
+def do_manual_sign(options):
+    _require_output_path(options, require_existing=True)
+    if options.signature is None:
+        raise AdminError("Must provide a signature (-g/--signature)")
+
+    info(f"Opening SGX migration authorization file {options.output_path}...")
+    sgx_authorization = SGXMigrationAuthorization.from_jsonfile(options.output_path)
+    info("Adding signature...")
+    sgx_authorization.add_signature(options.signature)
+    sgx_authorization.save_to_jsonfile(options.output_path)
+    info(f"SGX migration authorization saved to {options.output_path}")
+
+
+def do_key(options):
+    _require_output_path(options, require_existing=True)
+    if options.key is None:
+        raise AdminError("Must provide a signing key (-k/--key)")
+    if not is_hex_string_of_length(options.key, 32, allow_prefix=True):
+        raise AdminError(f"Invalid key '{options.key}'")
+
+    info(f"Opening SGX migration authorization file {options.output_path}...")
+    sgx_authorization = SGXMigrationAuthorization.from_jsonfile(options.output_path)
+    migration_spec = sgx_authorization.migration_spec
+    info("Signing with key...")
+    sk = ecdsa.SigningKey.from_string(
+        bytes.fromhex(options.key),
+        curve=ecdsa.SECP256k1
+    )
+    signature = sk.sign_digest(
+        migration_spec.get_authorization_digest(),
+        sigencode=ecdsa.util.sigencode_der
+    )
+    # Add the signature to the authorization and save it to disk
+    sgx_authorization.add_signature(signature.hex())
+    sgx_authorization.save_to_jsonfile(options.output_path)
+    info(f"SGX migration authorization saved to {options.output_path}")
+
+
+def do_eth(options):
+    _require_output_path(options)
+    if options.path is None:
+        options.path = DEFAULT_ETH_PATH
+    # Parse path
+    path = BIP32Path(options.path)
+    eth = None
+    try:
+        # Get dongle access (must have ethereum app open)
+        eth = get_eth_dongle(options.verbose)
+        # Retrieve public key
+        info(f"Retrieving public key for path '{str(path)}'...")
+        pubkey = eth.get_pubkey(path)
+        info(f"Public key: {pubkey.hex()}")
+
+        # If options.pubkey is True, we just want to retrieve the public key
+        if options.pubkey:
+            info(f"Opening public key file {options.output_path}...")
+            info("Adding public key...")
+            with open(options.output_path, "w") as file:
+                file.write("%s\n" % pubkey.hex())
+            info(f"Public key saved to {options.output_path}")
+            return
+
+        # Is there an existing migration authorization? Read it
+        sgx_authorization = None
+        if not isfile(options.output_path):
+            raise AdminError("Invalid SGX migration authorization file: "
+                             f"{options.output_path}")
+
+        info(f"Opening SGX migration authorization file {options.output_path}...")
+        sgx_authorization = SGXMigrationAuthorization.from_jsonfile(options.output_path)
+        migration_spec = sgx_authorization.migration_spec
+        info("Signing with dongle...")
+        try:
+            signature = eth.sign(path, migration_spec.msg.encode('ascii'))
+            vkey = ecdsa.VerifyingKey.from_string(pubkey, curve=ecdsa.SECP256k1)
+
+            if not vkey.verify_digest(
+                signature, migration_spec.get_authorization_digest(),
+                sigdecode=ecdsa.util.sigdecode_der
+            ):
+                raise Exception()
+        except Exception:
+            raise AdminError(f"Bad signature from dongle! (got '{signature.hex()}')")
+        # Add the signature to the authorization and save it to disk
+        sgx_authorization.add_signature(signature.hex())
+        sgx_authorization.save_to_jsonfile(options.output_path)
+        info(f"SGX migration authorization saved to {options.output_path}")
+    except AdminError:
+        raise
+    except Exception as e:
+        raise AdminError(f"Error signing with dongle: {e}")
+    finally:
+        dispose_eth_dongle(eth)
+
+
+def main():
+    logging.disable(logging.CRITICAL)
+
+    parser = ArgumentParser(
+        description="powHSM SGX migration authorization generation and signing tool"
+    )
+    parser.add_argument("operation", choices=["message", "key", "eth", "manual"])
+    parser.add_argument(
+        "-o",
+        "--output",
+        dest="output_path",
+        help="Destination file for SGX migration authorization.",
+    )
+    parser.add_argument(
+        "-k",
+        "--key",
+        dest="key",
+        help="Private key used for signing (only for 'key' option)."
+        "Must be a 32-byte hex-encoded string.",
+    )
+    parser.add_argument(
+        "-p",
+        "--path",
+        dest="path",
+        help="Path used for signing (only for 'eth' option). "
+        f"Default \"{DEFAULT_ETH_PATH}\""
+    )
+    parser.add_argument(
+        "-g",
+        "--signature",
+        dest="signature",
+        help="Signature to add to SGX migration authorization (only for 'manual' option)."
+        "Must be a hex-encoded, der-encoded SECP256k1 signature.",
+    )
+    parser.add_argument(
+        "-b",
+        "--pubkey",
+        dest="pubkey",
+        action="store_true",
+        help="Retrieve public key (only for 'eth' option)."
+    )
+    parser.add_argument(
+        "-e",
+        "--exporter",
+        dest="exporter_hash",
+        help="The hash of the exporter enclave (only for 'message' option)."
+    )
+    parser.add_argument(
+        "-i",
+        "--importer",
+        dest="importer_hash",
+        help="The hash of the importer enclave (only for 'message' option)."
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="verbose",
+        action="store_const",
+        help="Enable verbose mode",
+        default=False,
+        const=True,
+    )
+    options = parser.parse_args()
+
+    try:
+        if options.operation == "message":
+            do_message(options)
+        elif options.operation == "key":
+            do_key(options)
+        elif options.operation == "eth":
+            do_eth(options)
+        elif options.operation == "manual":
+            do_manual_sign(options)
+        else:
+            raise AdminError(f"Invalid operation: {options.operation}")
+        sys.exit(0)
+    except Exception as e:
+        info(str(e))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/middleware/signmigration.py
+++ b/middleware/signmigration.py
@@ -24,7 +24,6 @@ import sys
 from os.path import isfile
 from argparse import ArgumentParser
 import ecdsa
-import logging
 from admin.misc import (
     get_eth_dongle,
     dispose_eth_dongle,
@@ -160,8 +159,6 @@ def do_eth(options):
 
 
 def main():
-    logging.disable(logging.CRITICAL)
-
     parser = ArgumentParser(
         description="powHSM SGX migration authorization generation and signing tool"
     )

--- a/middleware/signmigration.py
+++ b/middleware/signmigration.py
@@ -130,9 +130,7 @@ def do_eth(options):
 
         # Is there an existing migration authorization? Read it
         sgx_authorization = None
-        if not isfile(options.output_path):
-            raise AdminError("Invalid SGX migration authorization file: "
-                             f"{options.output_path}")
+        _require_output_path(options, require_existing=True)
 
         info(f"Opening SGX migration authorization file {options.output_path}...")
         sgx_authorization = SGXMigrationAuthorization.from_jsonfile(options.output_path)

--- a/middleware/tests/admin/test_sgx_authorization.py
+++ b/middleware/tests/admin/test_sgx_authorization.py
@@ -1,0 +1,333 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021 RSK Labs Ltd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from unittest import TestCase
+from unittest.mock import patch, call, mock_open
+from admin.sgx_migration_authorization import SGXMigrationAuthorization, SGXMigrationSpec
+from comm.utils import keccak_256
+import json
+
+import logging
+
+logging.disable(logging.CRITICAL)
+
+
+class TestSGXAuthorization(TestCase):
+    def setUp(self):
+        # Sample valid DER signatures
+        self.sigs = [
+            "3045022100f31ee73e3b10c5d610d9f5501e12ce1f2fd31182d0630c8e0db75fba3f35bbe3022056d0703a27937aec36a0a05bd5b85de6144279ab3a66faf266378ce42a838831",  # noqa E501
+            "3046022100d2e039915b4decd3d32d613bdcfc84090560e0e714284ff4c3b454b563d81c7c022100ff0de20f22f75a87cf546a6e3dd9dada082b0bdd01862e1c566e5bdd67f0c3b1",  # noqa E501
+        ]
+
+        # Sample mrenclave values (32-byte hex strings)
+        self.exporter_mrenclave = "aa" * 32
+        self.importer_mrenclave = "bb" * 32
+
+        # Create migration spec
+        self.migration_spec = SGXMigrationSpec({
+            "exporter": self.exporter_mrenclave,
+            "importer": self.importer_mrenclave
+        })
+
+        # Create SGX authorization instance
+        self.sa = SGXMigrationAuthorization(self.migration_spec, self.sigs)
+
+    def test_migration_spec_n_signatures(self):
+        # Test basic property getters and verify signatures list is copied
+        self.assertEqual(self.sa.migration_spec.exporter, self.exporter_mrenclave)
+        self.assertEqual(self.sa.migration_spec.importer, self.importer_mrenclave)
+        self.assertEqual(self.sa.signatures, self.sigs)
+        self.assertIsNot(self.sa.signatures, self.sigs)  # Verify list is copied
+
+    def test_invalid_migration_spec(self):
+        # Test constructor with invalid migration spec
+        with self.assertRaises(ValueError):
+            SGXMigrationAuthorization("not-a-migration-spec", self.sigs)
+
+    def test_invalid_signatures(self):
+        # Test constructor with invalid signatures (non-list)
+        with self.assertRaises(ValueError):
+            SGXMigrationAuthorization(self.migration_spec, "not-an-array")
+
+    def test_invalid_signature(self):
+        # Test constructor with invalid signature format
+        with self.assertRaises(ValueError):
+            SGXMigrationAuthorization(
+                self.migration_spec,
+                [self.sigs[0], "not-a-valid-signature"]
+            )
+
+    def test_to_dict(self):
+        # Test dictionary conversion
+        expected_dict = {
+            "version": 1,
+            "hashes": {
+                "exporter": self.exporter_mrenclave,
+                "importer": self.importer_mrenclave,
+            },
+            "signatures": self.sigs
+        }
+        self.assertEqual(expected_dict, self.sa.to_dict())
+
+    def test_add_signature(self):
+        # Test adding a valid signature
+        new_sig = "3045022100d2dac5b641d6a454cacdff045ab428bfc4c86e"\
+                  "004ff69728050a33788f6e9e7602207e8b3536a7a50185e2"\
+                  "7219237358823b98678fe32aa7a30b31155cbffad3747d"
+        self.sa.add_signature(new_sig)
+        self.assertEqual(self.sa.signatures, self.sigs + [new_sig])
+
+    def test_add_duplicate_signature(self):
+        # Adding the same signature should be allowed
+        self.sa.add_signature(self.sigs[0])
+        self.assertEqual(self.sa.signatures, self.sigs + [self.sigs[0]])
+
+    def test_add_invalid_signature(self):
+        # Test signature validation with various invalid formats
+        invalid_signatures = [
+            "not-a-signature",
+            "0x1234",  # Too short
+            "0x" + "1" * 100,  # Too long
+        ]
+        for sig in invalid_signatures:
+            with self.assertRaises(ValueError):
+                self.sa.add_signature(sig)
+
+    def test_save_to_jsonfile(self):
+        # Test saving authorization to JSON file
+        with patch("builtins.open", mock_open()) as open_mock:
+            self.sa.save_to_jsonfile("/a/file/path.json")
+
+        self.assertEqual([call("/a/file/path.json", "w")], open_mock.call_args_list)
+        self.assertEqual([call(json.dumps(self.sa.to_dict(), indent=2))],
+                         open_mock.return_value.write.call_args_list)
+
+    def test_from_jsonfile(self):
+        # Test loading authorization from valid JSON file
+        jsonsample = """
+        {
+          "version": 1,
+          "hashes": {
+            "exporter": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "importer": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "signatures": [
+            "3045022100f31ee73e3b10c5d610d9f5501e12ce1f2fd31182d0630c8e0db75fba3f35bbe3022056d0703a27937aec36a0a05bd5b85de6144279ab3a66faf266378ce42a838831",
+            "3046022100d2e039915b4decd3d32d613bdcfc84090560e0e714284ff4c3b454b563d81c7c022100ff0de20f22f75a87cf546a6e3dd9dada082b0bdd01862e1c566e5bdd67f0c3b1"
+          ]
+        }
+        """  # noqa E501
+
+        with patch("builtins.open", mock_open()) as open_mock:
+            open_mock.return_value.read.return_value = jsonsample
+            sa = SGXMigrationAuthorization.from_jsonfile("/an/existing/file.json")
+
+        self.assertEqual([call("/an/existing/file.json", "r")], open_mock.call_args_list)
+        self.assertEqual("aa" * 32, sa.migration_spec.exporter)
+        self.assertEqual("bb" * 32, sa.migration_spec.importer)
+        self.assertEqual(
+            [
+                "3045022100f31ee73e3b10c5d610d9f5501e12ce1f2fd31182d0630c8e0db75fba3f35bbe3022056d0703a27937aec36a0a05bd5b85de6144279ab3a66faf266378ce42a838831",  # noqa E501
+                "3046022100d2e039915b4decd3d32d613bdcfc84090560e0e714284ff4c3b454b563d81c7c022100ff0de20f22f75a87cf546a6e3dd9dada082b0bdd01862e1c566e5bdd67f0c3b1"  # noqa E501
+            ],
+            sa.signatures)
+
+    def test_from_jsonfile_invalid_json(self):
+        # Test loading authorization from invalid JSON file
+        jsonsample = """
+        { THISISNOTJSON
+          "version": 1,
+          "hashes": {
+            "exporter": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "importer": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "signatures": []
+        }
+        """  # noqa E501
+
+        with patch("builtins.open", mock_open()) as open_mock:
+            open_mock.return_value.read.return_value = jsonsample
+
+            with self.assertRaises(ValueError):
+                SGXMigrationAuthorization.from_jsonfile("/an/existing/file.json")
+
+    def test_from_jsonfile_invalid_version(self):
+        # Test loading authorization with invalid version
+        jsonsample = """
+        {
+          "version": 2,
+          "hashes": {
+            "exporter": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "importer": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "signatures": []
+        }
+        """  # noqa E501
+
+        with patch("builtins.open", mock_open()) as open_mock:
+            open_mock.return_value.read.return_value = jsonsample
+
+            with self.assertRaises(ValueError):
+                SGXMigrationAuthorization.from_jsonfile("/an/existing/file.json")
+
+    def test_from_jsonfile_invalid_migration_spec(self):
+        # Test loading authorization with invalid migration spec
+        jsonsample = """
+        {
+          "version": 1,
+          "hashes": {
+            "exporter": "not-a-mrenclave",
+            "importer": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "signatures": []
+        }
+        """
+
+        with patch("builtins.open", mock_open()) as open_mock:
+            open_mock.return_value.read.return_value = jsonsample
+
+            with self.assertRaises(ValueError):
+                SGXMigrationAuthorization.from_jsonfile("/an/existing/file.json")
+
+    def test_from_jsonfile_invalid_signatures(self):
+        # Test loading authorization with invalid signatures format
+        jsonsample = """
+        {
+          "version": 1,
+          "hashes": {
+            "exporter": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "importer": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "signatures": "not-signatures"
+        }
+        """  # noqa E501
+
+        with patch("builtins.open", mock_open()) as open_mock:
+            open_mock.return_value.read.return_value = jsonsample
+
+            with self.assertRaises(ValueError):
+                SGXMigrationAuthorization.from_jsonfile("/an/existing/file.json")
+
+    def test_from_jsonfile_invalid_signature(self):
+        # Test loading authorization with invalid signature format
+        jsonsample = """
+        {
+          "version": 1,
+          "hashes": {
+            "exporter": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "importer": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "signatures": [
+              "not-a-signature",
+              "304402201ef9d2a728e86aa3e8a0cf27a1f6afeba84af90f89ea50ea14483c4bd0c17fcd02201b6130ab0aed38128a4637b93ac90484aa2361c014e89c915d061fd27cab6aa6"
+          ]
+        }
+        """  # noqa E501
+
+        with patch("builtins.open", mock_open()) as open_mock:
+            open_mock.return_value.read.return_value = jsonsample
+
+            with self.assertRaises(ValueError):
+                SGXMigrationAuthorization.from_jsonfile("/an/existing/file.json")
+
+    def test_authorization_message(self):
+        # Test authorization message format
+        expected_msg = (b"\x19Ethereum Signed Message:\n" +
+                        b"160" +
+                        b"RSK_powHSM_SGX_upgrade_from_" +
+                        self.exporter_mrenclave.encode("ASCII") +
+                        b"_to_" + self.importer_mrenclave.encode("ASCII"))
+        self.assertEqual(expected_msg, self.sa.migration_spec.get_authorization_msg())
+
+    def test_authorization_digest(self):
+        # Test authorization digest generation
+        msg = self.sa.migration_spec.get_authorization_msg()
+        expected_digest = keccak_256(msg)
+        self.assertEqual(
+            expected_digest,
+            self.sa.migration_spec.get_authorization_digest()
+        )
+
+
+class TestMigrationSpec(TestCase):
+    def setUp(self):
+        # Sample mrenclave values (32-byte hex strings)
+        self.exporter_mrenclave = "aa" * 32
+        self.importer_mrenclave = "bb" * 32
+        self.migration_spec = SGXMigrationSpec({
+            "exporter": self.exporter_mrenclave,
+            "importer": self.importer_mrenclave
+        })
+
+    def test_mrenclave_getters(self):
+        # Test mrenclave getters and normalization
+        self.assertEqual(self.migration_spec.exporter, self.exporter_mrenclave.lower())
+        self.assertEqual(self.migration_spec.importer, self.importer_mrenclave.lower())
+
+    def test_invalid_exporter_mrenclave(self):
+        # Test constructor with invalid exporter mrenclave
+        with self.assertRaises(ValueError):
+            SGXMigrationSpec({
+                "exporter": "not-a-mrenclave",
+                "importer": self.importer_mrenclave
+            })
+
+    def test_invalid_importer_mrenclave(self):
+        # Test constructor with invalid importer mrenclave
+        with self.assertRaises(ValueError):
+            SGXMigrationSpec({
+                "exporter": self.exporter_mrenclave,
+                "importer": "not-a-mrenclave"
+            })
+
+    def test_mrenclave_normalization(self):
+        # Test mrenclave hex string normalization
+        spec = SGXMigrationSpec({
+            "exporter": "0x" + "aa" * 32,
+            "importer": "0x" + "bb" * 32
+        })
+        self.assertEqual(spec.exporter, "aa" * 32)
+        self.assertEqual(spec.importer, "bb" * 32)
+
+    def test_to_dict(self):
+        # Test dictionary conversion
+        expected_dict = {
+            "exporter": self.exporter_mrenclave,
+            "importer": self.importer_mrenclave,
+        }
+        self.assertEqual(expected_dict, self.migration_spec.to_dict())
+
+    def test_authorization_message(self):
+        # Test authorization message format
+        expected_msg = (b"\x19Ethereum Signed Message:\n" +
+                        b"160" +
+                        b"RSK_powHSM_SGX_upgrade_from_" +
+                        self.exporter_mrenclave.encode("ASCII") +
+                        b"_to_" + self.importer_mrenclave.encode("ASCII"))
+        self.assertEqual(expected_msg, self.migration_spec.get_authorization_msg())
+
+    def test_authorization_digest(self):
+        # Test authorization digest generation
+        msg = self.migration_spec.get_authorization_msg()
+        expected_digest = keccak_256(msg)
+        self.assertEqual(expected_digest, self.migration_spec.get_authorization_digest())

--- a/middleware/tests/admin/test_signmigration.py
+++ b/middleware/tests/admin/test_signmigration.py
@@ -1,0 +1,294 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021 RSK Labs Ltd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from unittest import TestCase
+from unittest.mock import Mock, call, patch
+from signmigration import main
+from admin.bip32 import BIP32Path
+import ecdsa
+import logging
+
+logging.disable(logging.CRITICAL)
+
+RETURN_SUCCESS = 0
+RETURN_ERROR = 1
+
+
+@patch("signmigration.SGXMigrationAuthorization")
+@patch("signmigration.SGXMigrationSpec")
+@patch("signmigration.info")
+class TestSignMigrationMessage(TestCase):
+    def setUp(self):
+        self.migration_auth = Mock()
+        self.migration_spec = Mock()
+        self.migration_spec.get_authorization_msg.return_value = (
+            b"the-authorization-message"
+        )
+        self.migration_auth.for_spec.return_value = self.migration_auth
+
+    def test_ok_to_console(self, info_mock, migration_spec_mock, migration_auth_mock):
+        migration_spec_mock.return_value = self.migration_spec
+        migration_auth_mock.for_spec.return_value = self.migration_auth
+
+        with patch("sys.argv", ["signmigration.py", "message",
+                                "-e", "exporter-hash",
+                                "-i", "importer-hash"]):
+            with self.assertRaises(SystemExit) as exit:
+                main()
+
+        self.assertEqual(exit.exception.code, RETURN_SUCCESS)
+        self.assertEqual(
+            [call("Computing the SGX migration authorization message..."),
+             call("the-authorization-message")], info_mock.call_args_list
+        )
+        self.assertEqual(
+            [call({"exporter": "exporter-hash", "importer": "importer-hash"})],
+            migration_spec_mock.call_args_list
+        )
+        self.assertEqual(
+            [call(self.migration_spec)],
+            migration_auth_mock.for_spec.call_args_list
+        )
+
+    def test_ok_to_file(self, info_mock, migration_spec_mock, migration_auth_mock):
+        migration_spec_mock.return_value = self.migration_spec
+        migration_auth_mock.for_spec.return_value = self.migration_auth
+
+        with patch("sys.argv", ["signmigration.py", "message",
+                                "-e", "exporter-hash",
+                                "-i", "importer-hash",
+                                "-o", "an-output-path"]):
+            with self.assertRaises(SystemExit) as exit:
+                main()
+
+        self.assertEqual(exit.exception.code, RETURN_SUCCESS)
+        self.assertEqual(
+            [call("Computing the SGX migration authorization message..."),
+             call("SGX migration authorization saved to an-output-path")],
+            info_mock.call_args_list
+        )
+        self.assertEqual(
+            [call({"exporter": "exporter-hash", "importer": "importer-hash"})],
+            migration_spec_mock.call_args_list
+        )
+        self.assertEqual(
+            [call(self.migration_spec)],
+            migration_auth_mock.for_spec.call_args_list
+        )
+        self.assertEqual(
+            [call("an-output-path")],
+            self.migration_auth.save_to_jsonfile.call_args_list
+        )
+
+
+@patch("signmigration.isfile")
+@patch("signmigration.SGXMigrationAuthorization")
+@patch("signmigration.info")
+class TestSignMigrationManual(TestCase):
+    def test_ok(self, info_mock, migration_auth_mock, isfile_mock):
+        migration_auth = Mock()
+        migration_auth_mock.from_jsonfile.return_value = migration_auth
+        isfile_mock.return_value = True
+
+        with patch("sys.argv", ["signmigration.py", "manual",
+                                "-o", "an-output-path",
+                                "-g", "a-signature"]):
+            with self.assertRaises(SystemExit) as exit:
+                main()
+
+        self.assertEqual(exit.exception.code, RETURN_SUCCESS)
+        self.assertEqual(
+            [call("an-output-path")],
+            migration_auth_mock.from_jsonfile.call_args_list
+        )
+        self.assertEqual(
+            [call("a-signature")],
+            migration_auth.add_signature.call_args_list
+        )
+        self.assertEqual(
+            [call("an-output-path")],
+            migration_auth.save_to_jsonfile.call_args_list
+        )
+        self.assertEqual(
+            [
+                call("Opening SGX migration authorization file an-output-path..."),
+                call("Adding signature..."),
+                call("SGX migration authorization saved to an-output-path")
+            ],
+            info_mock.call_args_list
+        )
+
+    def test_file_not_found(self, info_mock, migration_auth_mock, isfile_mock):
+        isfile_mock.return_value = False
+
+        with patch("sys.argv", ["signmigration.py", "manual",
+                                "-o", "an-output-path",
+                                "-g", "a-signature"]):
+            with self.assertRaises(SystemExit) as exit:
+                main()
+
+        self.assertEqual(exit.exception.code, RETURN_ERROR)
+        self.assertEqual(
+            [
+                call("Invalid output path: an-output-path")
+            ],
+            info_mock.call_args_list
+        )
+        migration_auth_mock.from_jsonfile.assert_not_called()
+
+
+@patch("signmigration.isfile")
+@patch("signmigration.SGXMigrationAuthorization")
+@patch("signmigration.info")
+class TestSignMigrationKey(TestCase):
+    def test_ok(self, info_mock, migration_auth_mock, isfile_mock):
+        migration_auth = Mock()
+        migration_auth_mock.from_jsonfile.return_value = migration_auth
+        migration_auth.add_signature.return_value = None
+        isfile_mock.return_value = True
+        migration_auth.migration_spec.get_authorization_digest.return_value = (
+            bytes.fromhex("bb"*32)
+        )
+
+        with patch("sys.argv", ["signmigration.py", "key",
+                                "-o", "an-output-path",
+                                "-k", "aa"*32]):
+            with self.assertRaises(SystemExit) as exit:
+                main()
+
+        privkey = ecdsa.SigningKey.from_string(
+            bytes.fromhex("aa"*32),
+            curve=ecdsa.SECP256k1
+        )
+        pubkey = privkey.get_verifying_key()
+        signature = migration_auth.add_signature.call_args_list[0][0][0]
+        pubkey.verify_digest(bytes.fromhex(signature), bytes.fromhex("bb"*32),
+                             sigdecode=ecdsa.util.sigdecode_der)
+        self.assertEqual(exit.exception.code, RETURN_SUCCESS)
+        self.assertEqual(
+            [call("an-output-path")],
+            migration_auth_mock.from_jsonfile.call_args_list
+        )
+        self.assertEqual(
+            [
+                call("Opening SGX migration authorization file an-output-path..."),
+                call("Signing with key..."),
+                call("SGX migration authorization saved to an-output-path")
+            ],
+            info_mock.call_args_list
+        )
+
+
+@patch("signmigration.isfile")
+@patch("signmigration.dispose_eth_dongle")
+@patch("signmigration.get_eth_dongle")
+@patch("signmigration.BIP32Path")
+@patch("signmigration.SGXMigrationSpec")
+@patch("signmigration.SGXMigrationAuthorization")
+@patch("signmigration.info")
+class TestSignMigrationEth(TestCase):
+    def test_ok_pubkey(
+            self,
+            info_mock,
+            migration_auth_mock,
+            migration_spec_mock,
+            bip32path_mock,
+            get_eth_mock,
+            dispose_eth_mock,
+            isfile_mock):
+        migration_auth = Mock()
+        migration_auth_mock.from_jsonfile.return_value = migration_auth
+        bip32path_mock.return_value = "bip32-path"
+        get_eth_mock.return_value = Mock()
+        eth_mock = Mock()
+        eth_mock.get_pubkey.return_value = bytes.fromhex("aa"*32)
+        eth_mock.sign.return_value = bytes.fromhex("bb"*32)
+        get_eth_mock.return_value = eth_mock
+        isfile_mock.return_value = True
+
+        with patch("sys.argv", ["signmigration.py", "eth",
+                                "-o", "an-output-path", "-b"]):
+            with self.assertRaises(SystemExit) as exit:
+                main()
+
+        self.assertEqual(exit.exception.code, RETURN_SUCCESS)
+        get_eth_mock.assert_called_once()
+        eth_mock.get_pubkey.assert_called_once_with("bip32-path")
+        self.assertEqual(
+            [
+                call("Retrieving public key for path 'bip32-path'..."),
+                call("Public key: " + "aa"*32),
+                call("Opening public key file an-output-path..."),
+                call("Adding public key..."),
+                call("Public key saved to an-output-path")
+            ],
+            info_mock.call_args_list
+        )
+
+    def test_existingfile_ok(
+            self,
+            info_mock,
+            migration_auth_mock,
+            migration_spec_mock,
+            bip32path_mock,
+            get_eth_mock,
+            dispose_eth_mock,
+            isfile_mock):
+        migration_spec_mock = Mock()
+        migration_spec_mock.get_authorization_digest.return_value = bytes.fromhex("aa"*32)
+        migration_spec_mock.msg = "RSK_powHSM_SGX_upgrade_from_exporter_to_importer"
+        migration_auth = Mock()
+        migration_auth.migration_spec = migration_spec_mock
+        migration_auth_mock.from_jsonfile.return_value = migration_auth
+        bip32path_mock.return_value = BIP32Path("m/44'/60'/0'/0/0")
+        privkey = ecdsa.SigningKey.from_string(bytes.fromhex("dd"*32),
+                                               curve=ecdsa.SECP256k1)
+        pubkey = privkey.get_verifying_key()
+        eth_mock = Mock()
+        eth_mock.get_pubkey.return_value = pubkey.to_string("uncompressed")
+        eth_mock.sign.return_value = privkey.sign_digest(
+            bytes.fromhex("aa"*32), sigencode=ecdsa.util.sigencode_der)
+        get_eth_mock.return_value = eth_mock
+        isfile_mock.return_value = True
+
+        with patch("sys.argv", ["signmigration.py", "eth",
+                                "-o", "an-output-path"]):
+            with self.assertRaises(SystemExit) as exit:
+                main()
+
+        self.assertEqual(exit.exception.code, RETURN_SUCCESS)
+
+        self.assertEqual([call("an-output-path")], isfile_mock.call_args_list)
+        self.assertFalse(migration_spec_mock.called)
+        self.assertEqual([call("an-output-path")],
+                         migration_auth_mock.from_jsonfile.call_args_list)
+        self.assertEqual([call(BIP32Path("m/44'/60'/0'/0/0"))],
+                         eth_mock.get_pubkey.call_args_list)
+        self.assertEqual([call(BIP32Path("m/44'/60'/0'/0/0"),
+                         b"RSK_powHSM_SGX_upgrade_from_exporter_to_importer")],
+                         eth_mock.sign.call_args_list)
+        self.assertEqual(1, migration_auth.add_signature.call_count)
+        signature = migration_auth.add_signature.call_args_list[0][0][0]
+        pubkey.verify_digest(bytes.fromhex(signature), bytes.fromhex("aa"*32),
+                             sigdecode=ecdsa.util.sigdecode_der)
+        self.assertEqual([call("an-output-path")],
+                         migration_auth.save_to_jsonfile.call_args_list)


### PR DESCRIPTION
Introduces a new tool for creating and signing SGX migration authorizations between enclaves. The tool follows a similar pattern to the existing signapp.py tool.