### PR TITLE
SGX upgrade shared key computation

### DIFF
--- a/firmware/src/hal/sgx/src/trusted/evidence.c
+++ b/firmware/src/hal/sgx/src/trusted/evidence.c
@@ -227,6 +227,11 @@ oe_claim_t* evidence_get_claim(oe_claim_t* claims,
     return NULL;
 }
 
+oe_claim_t* evidence_get_custom_claim(oe_claim_t* claims, size_t claims_size) {
+    return evidence_get_claim(
+        claims, claims_size, OE_CLAIM_CUSTOM_CLAIMS_BUFFER);
+}
+
 void evidence_free(uint8_t* evidence_buffer) {
     if (evidence_buffer)
         oe_free_evidence(evidence_buffer);

--- a/firmware/src/hal/sgx/src/trusted/evidence.h
+++ b/firmware/src/hal/sgx/src/trusted/evidence.h
@@ -95,15 +95,45 @@ bool evidence_generate(evidence_format_t* format,
                        uint8_t** evidence_buffer,
                        size_t* evidence_buffer_size);
 
+/**
+ * @brief Verify and extract claims from a given evidence
+ *
+ * @param format_id             the evidence format
+ * @param evidence_buffer       the evidence buffer
+ * @param evidence_buffer_size  the evidence buffer size
+ * @param claims                [out] claims buffer
+ * @param claims_size           [out] number of claims
+ *
+ * @returns true iff evidence was successfully verified
+ */
 bool evidence_verify_and_extract_claims(oe_uuid_t format_id,
                                         uint8_t* evidence_buffer,
                                         size_t evidence_buffer_size,
                                         oe_claim_t** claims,
                                         size_t* claims_size);
 
+/**
+ * @brief Given a set of claims, find the one with the given name
+ *
+ * @param claims        the claim list
+ * @param claims_size   the number of claims
+ * @param claim_name    target claim name
+ *
+ * @returns the claim, or NULL if no claim with that name was found
+ */
 oe_claim_t* evidence_get_claim(oe_claim_t* claims,
                                size_t claims_size,
                                const char* claim_name);
+
+/**
+ * @brief Given a set of claims, find the custom claim
+ *
+ * @param claims        the claim list
+ * @param claims_size   the number of claims
+ *
+ * @returns the custom claim, or NULL if no custom claim was found
+ */
+oe_claim_t* evidence_get_custom_claim(oe_claim_t* claims, size_t claims_size);
 
 /**
  * @brief Frees a buffer previously output by evidence_generate

--- a/firmware/src/hal/sgx/test/evidence/test_evidence.c
+++ b/firmware/src/hal/sgx/test/evidence/test_evidence.c
@@ -634,6 +634,49 @@ void test_evidence_get_claim_behaves_ok_with_invalid_params() {
     assert(!evidence_get_claim((oe_claim_t*)"valid-pointer", 13, NULL));
 }
 
+void test_evidence_get_custom_claim_ok() {
+    printf("Testing evidence_get_custom_claim succeeds...\n");
+
+    oe_claim_t claim1 = {
+        .name = "claim1_name",
+        .value = (uint8_t*)"claim1_value",
+        .value_size = strlen("claim1_value"),
+    };
+    oe_claim_t claim2 = {
+        .name = "claim2_name",
+        .value = (uint8_t*)"claim2_value",
+        .value_size = strlen("claim2_value"),
+    };
+    oe_claim_t custom_claims = {
+        .name = "custom_claims_buffer",
+        .value = (uint8_t*)"the custom claim buffer",
+        .value_size = strlen("the custom claim buffer"),
+    };
+
+    oe_claim_t claims[] = {claim1, custom_claims, claim2};
+    oe_claim_t claims_nocustom[] = {claim1, claim2};
+
+    oe_claim_t* found =
+        evidence_get_custom_claim(claims, sizeof(claims) / sizeof(claims[0]));
+    assert(found);
+    assert(!memcmp(
+        found->name, "custom_claims_buffer", strlen("custom_claims_buffer")));
+    assert(strlen("the custom claim buffer") == found->value_size);
+    assert(!memcmp(found->value, "the custom claim buffer", found->value_size));
+
+    assert(!evidence_get_custom_claim(
+        claims_nocustom, sizeof(claims_nocustom) / sizeof(claims_nocustom[0])));
+}
+
+void test_evidence_get_custom_claim_behaves_ok_with_invalid_params() {
+    printf("Testing evidence_get_custom_claim behaves correctly with invalid "
+           "parameters...\n");
+    setup();
+
+    assert(!evidence_get_custom_claim(NULL, 123));
+    assert(!evidence_get_custom_claim((oe_claim_t*)"valid-pointer", 0));
+}
+
 void test_evidence_free() {
     printf("Testing evidence_free...\n");
     setup();
@@ -673,5 +716,9 @@ int main() {
 
     test_evidence_get_claim_ok();
     test_evidence_get_claim_behaves_ok_with_invalid_params();
+
+    test_evidence_get_custom_claim_ok();
+    test_evidence_get_custom_claim_behaves_ok_with_invalid_params();
+
     test_evidence_free();
 }

--- a/firmware/src/hal/sgx/test/mock/openenclave/common.h
+++ b/firmware/src/hal/sgx/test/mock/openenclave/common.h
@@ -219,6 +219,8 @@ OE_PACK_END
 
 #define OE_CLAIM_UNIQUE_ID "unique_id"
 
+#define OE_CLAIM_CUSTOM_CLAIMS_BUFFER "custom_claims_buffer"
+
 typedef struct _oe_uuid_t {
     uint8_t b[OE_UUID_SIZE];
 } oe_uuid_t;

--- a/firmware/src/sgx/src/trusted/aes_gcm.c
+++ b/firmware/src/sgx/src/trusted/aes_gcm.c
@@ -31,9 +31,9 @@
 #include <openenclave/corelibc/stdlib.h>
 #include <mbedtls/gcm.h>
 
-#define AES_KEY_SIZE 32 // AES-256
-#define AES_IV_SIZE 12  // Recommended IV size for GCM
-#define AES_TAG_SIZE 16 // Authentication tag size
+#define AES_GCM_KEY_SIZE 32 // AES-256
+#define AES_IV_SIZE 12      // Recommended IV size for GCM
+#define AES_TAG_SIZE 16     // Authentication tag size
 
 size_t aes_gcm_get_encrypted_size(size_t cleartext_size) {
     if (cleartext_size + AES_IV_SIZE + AES_TAG_SIZE < cleartext_size)
@@ -55,8 +55,9 @@ bool aes_gcm_encrypt(uint8_t* key,
     uint8_t* ciphertext = NULL;
 
     // Sizes check
-    if (AES_KEY_SIZE != key_size) {
-        LOG("AES-GCM encrypt error: expected a %u-byte key\n", AES_KEY_SIZE);
+    if (AES_GCM_KEY_SIZE != key_size) {
+        LOG("AES-GCM encrypt error: expected a %u-byte key\n",
+            AES_GCM_KEY_SIZE);
         goto aes_gcm_encrypt_exit;
     }
     if (in_size == 0) {
@@ -125,8 +126,9 @@ bool aes_gcm_decrypt(uint8_t* key,
     size_t cleartext_size = in_size - AES_IV_SIZE - AES_TAG_SIZE;
 
     // Sizes check
-    if (AES_KEY_SIZE != key_size) {
-        LOG("AES-GCM decrypt error: expected a %u-byte key\n", AES_KEY_SIZE);
+    if (AES_GCM_KEY_SIZE != key_size) {
+        LOG("AES-GCM decrypt error: expected a %u-byte key\n",
+            AES_GCM_KEY_SIZE);
         goto aes_gcm_decrypt_exit;
     }
     if (in_size <= AES_IV_SIZE + AES_TAG_SIZE) {

--- a/firmware/src/sgx/src/trusted/aes_gcm.h
+++ b/firmware/src/sgx/src/trusted/aes_gcm.h
@@ -29,6 +29,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#define AES_GCM_KEY_SIZE 32 // AES-256
+
 /**
  * @brief Gets the size of encrypted content for
  * the given cleartext size


### PR DESCRIPTION
- Added private/public keypair generation and addition to self evidence
- Added peer public key extraction upon peer evidence parsing
- Added shared secret computation for data migration
- Removed dummy key
- Added custom claim finder function to evidence module
- Completed evidence function docs
- Added shared key computation unit tests
- Added `evidence_get_custom_claim` function unit tests
- Fixed failing unit tests