### PR TITLE
Uninstall script for SGX setup

### DIFF
--- a/build-dist-sgx
+++ b/build-dist-sgx
@@ -34,7 +34,7 @@ echo -e "\e[32mBuilding into \e[93m$DEST_DIR\e[32m with checkpoint \e[93m$CHECKP
 echo -e "\e[33mCopying files and creating directories...\e[0m"
 rm -rf $DEST_DIR
 cp -RfL $ROOT_DIR/dist/sgx $DEST_DIR
-rm $DEST_DIR/.gitignore
+rm -f $DEST_DIR/.gitignore
 
 rm -rf $BIN_DIR
 mkdir -p $BIN_DIR

--- a/dist/misc/uninstall-sgx-powhsm
+++ b/dist/misc/uninstall-sgx-powhsm
@@ -23,6 +23,13 @@ function promptUserConfirmation() {
     fi
 }
 
+function checkExistingBackup() {
+    if [ -f "backup.tgz" ]; then
+        echo "Error: backup.tgz already exists. Please remove it first."
+        exit 1
+    fi
+}
+
 function backupInstallDirectory() {
     if [ ! -f "/etc/systemd/system/$SERVICE_NAME" ]; then
         echo "Service unit file not found, skipping backup."
@@ -40,13 +47,8 @@ function backupInstallDirectory() {
         return
     fi
 
-    if [ -f "backup.tgz" ]; then
-        echo "Error: backup.tgz already exists. Please remove it first."
-        exit 1
-    fi
-
     echo "Creating backup of $WORKING_DIR..."
-    tar czf backup.tgz -C "$(dirname "$WORKING_DIR")" "$(basename "$WORKING_DIR")"
+    tar czf backup.tgz -C $WORKING_DIR $WORKING_DIR
     error "Failed to create backup."
 
     echo "Backup created successfully! Find the previous installation in the backup.tgz file."
@@ -119,6 +121,7 @@ echo "Welcome to the SGX powHSM uninstall utility"
 echo
 
 promptUserConfirmation
+checkExistingBackup
 echo
 removeService
 echo

--- a/dist/misc/uninstall-sgx-powhsm
+++ b/dist/misc/uninstall-sgx-powhsm
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# The name of the service unit that will be uninstalled
+SERVICE_NAME=powhsmsgx.service
+# The internal network name for the powHSM service
+NETWORK=powhsmsgx_net
+# The user name created during the installation
+USER=powhsm
+
+function error() {
+    if [ $? -ne 0 ]; then
+        echo "Error: $1"
+        exit 1
+    fi
+}
+
+function promptUserConfirmation() {
+    echo "Are you sure you want to uninstall the powHSM SGX service from this machine?"
+    read -p "Proceed? [y/N]: " confirm
+    if [ "$confirm" != "Y" ] && [ "$confirm" != "y" ]; then
+        echo "Uninstall cancelled."
+        exit 1
+    fi
+}
+
+function backupInstallDirectory() {
+    if [ ! -f "/etc/systemd/system/$SERVICE_NAME" ]; then
+        echo "Service unit file not found, skipping backup."
+        return
+    fi
+
+    WORKING_DIR=$(grep "^WorkingDirectory=" "/etc/systemd/system/$SERVICE_NAME" | cut -d'=' -f2)
+    if [ -z "$WORKING_DIR" ]; then
+        echo "Could not determine working directory from service unit. Aborting."
+        exit 1
+    fi
+
+    if [ ! -d "$WORKING_DIR" ]; then
+        echo "Working directory $WORKING_DIR does not exist, skipping backup."
+        return
+    fi
+
+    if [ -f "backup.tgz" ]; then
+        echo "Error: backup.tgz already exists. Please remove it first."
+        exit 1
+    fi
+
+    echo "Creating backup of $WORKING_DIR..."
+    tar czf backup.tgz -C "$(dirname "$WORKING_DIR")" "$(basename "$WORKING_DIR")"
+    error "Failed to create backup."
+
+    echo "Backup created successfully! Find the previous installation in the backup.tgz file."
+}
+
+function removeService() {
+    echo "Checking if $SERVICE_NAME is installed..."
+    if ! systemctl list-units --full --all | grep -Fq $SERVICE_NAME; then
+        echo "Service is not installed."
+        return
+    fi
+
+    if systemctl is-active --quiet $SERVICE_NAME; then
+        echo "Stopping $SERVICE_NAME..."
+        systemctl stop $SERVICE_NAME
+        error "Could not stop $SERVICE_NAME."
+    fi
+
+    if systemctl is-enabled --quiet $SERVICE_NAME; then
+        echo "Disabling $SERVICE_NAME..."
+        systemctl disable $SERVICE_NAME
+        error "Could not disable $SERVICE_NAME."
+    fi
+
+    echo "Backing up install directory..."
+    backupInstallDirectory
+
+    echo "Removing $SERVICE_NAME..."
+    rm -f /etc/systemd/system/$SERVICE_NAME
+    error "Could not remove $SERVICE_NAME."
+
+    echo "Reloading systemd daemon..."
+    systemctl daemon-reload
+    error "Could not reload systemd daemon."
+
+    echo "Resetting failed state for $SERVICE_NAME (if any)..."
+    systemctl reset-failed "$SERVICE_NAME" &> /dev/null
+}
+
+function removeUser() {
+    echo "Checking for $USER user..."
+    if ! id -u $USER >/dev/null 2>&1; then
+        echo "User $USER does not exist."
+        return
+    fi
+
+    echo "Removing $USER user..."
+    userdel $USER
+    error "Could not remove the $USER user."
+}
+
+function removeNetwork() {
+    echo "Checking for $NETWORK docker network..."
+    if ! docker network ls | grep -Fq $NETWORK; then
+        echo "Network $NETWORK does not exist."
+        return
+    fi
+
+    echo "Removing $NETWORK docker network..."
+    docker network rm $NETWORK
+    error "Could not remove the $NETWORK docker network."
+}
+
+if ! [ "$(id -u)" == "0" ]; then
+    echo "Please run with sudo."
+    exit 1
+fi
+
+echo "Welcome to the SGX powHSM uninstall utility"
+echo
+
+promptUserConfirmation
+echo
+removeService
+echo
+removeUser
+echo
+removeNetwork
+echo
+
+echo "HSM SGX powHSM uninstall done."

--- a/dist/misc/uninstall-sgx-powhsm
+++ b/dist/misc/uninstall-sgx-powhsm
@@ -48,7 +48,7 @@ function backupInstallDirectory() {
     fi
 
     echo "Creating backup of $WORKING_DIR..."
-    tar czf backup.tgz -C $WORKING_DIR $WORKING_DIR
+    tar czf backup.tgz -C $WORKING_DIR .
     error "Failed to create backup."
 
     echo "Backup created successfully! Find the previous installation in the backup.tgz file."

--- a/dist/misc/uninstall-sgx-powhsm
+++ b/dist/misc/uninstall-sgx-powhsm
@@ -124,8 +124,8 @@ fi
 echo "Welcome to the SGX powHSM uninstall utility"
 echo
 
-promptUserConfirmation
 checkExistingBackup
+promptUserConfirmation
 echo
 removeService
 echo

--- a/dist/misc/uninstall-sgx-powhsm
+++ b/dist/misc/uninstall-sgx-powhsm
@@ -76,6 +76,10 @@ function removeService() {
     echo "Backing up install directory..."
     backupInstallDirectory
 
+    echo "Removing install directory..."
+    rm -rf $WORKING_DIR
+    error "Could not remove $WORKING_DIR."
+
     echo "Removing $SERVICE_NAME..."
     rm -f /etc/systemd/system/$SERVICE_NAME
     error "Could not remove $SERVICE_NAME."


### PR DESCRIPTION
Adds a standalone bash script for completely removing the current SGX powHSM installation from the machine. This can be used before a new onboarding to ensure that all the previously installed assets are cleared.