### PR TITLE
SGX upgrade DB migration admin tooling

### DIFF
--- a/middleware/adm_sgx.py
+++ b/middleware/adm_sgx.py
@@ -32,6 +32,7 @@ from admin.pubkeys import do_get_pubkeys
 from admin.changepin import do_changepin
 from admin.sgx_attestation import do_attestation
 from admin.verify_sgx_attestation import do_verify_attestation
+from admin.migrate_db import do_migrate_db
 
 
 def main():
@@ -44,6 +45,7 @@ def main():
         "changepin": do_changepin,
         "attestation": do_attestation,
         "verify_attestation": do_verify_attestation,
+        "migrate_db": do_migrate_db,
     }
 
     parser = ArgumentParser(description="SGX powHSM Administrative tool")
@@ -124,6 +126,28 @@ def main():
         "--pubkeys",
         dest="pubkeys_file_path",
         help="Public keys file (only valid for 'verify_attestation' operation).",
+    )
+    parser.add_argument(
+        "--dest-port",
+        dest="destination_sgx_port",
+        help="Destination SGX powHSM listening port (default 3333) "
+             "(only valid for 'migrate_db' operations)",
+        type=int,
+        default=3333,
+    )
+    parser.add_argument(
+        "--dest-host",
+        dest="destination_sgx_host",
+        help="Destination SGX powHSM host. (default 'localhost') "
+             "(only valid for 'migrate_db' operations)",
+        default="localhost",
+    )
+    parser.add_argument(
+        "-z",
+        "--migauth",
+        dest="migration_authorization_file_path",
+        help="Migration authorization file (only valid for 'migrate_db' "
+        "operation).",
     )
     parser.add_argument(
         "-v",

--- a/middleware/admin/migrate_db.py
+++ b/middleware/admin/migrate_db.py
@@ -1,0 +1,109 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021 RSK Labs Ltd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from .misc import info, head, get_hsm, get_sgx_hsm, dispose_hsm, AdminError
+from .unlock import do_unlock
+from .sgx_migration_authorization import SGXMigrationAuthorization
+from sgx.hsm2dongle import SgxUpgradeRoles
+
+
+def do_migrate_db(options):
+    head("### -> Migrate DB", fill="#")
+    hsm_src = None
+    hsm_dst = None
+
+    if options.destination_sgx_port is None or \
+       options.destination_sgx_host is None:
+        raise AdminError("Destination SGX powHSM host and port must be provided")
+
+    # Require a migration authorization file
+    if options.migration_authorization_file_path is None:
+        raise AdminError("No migration authorization file path given")
+
+    # Load the given migration authorization
+    try:
+        migration_authorization = SGXMigrationAuthorization.from_jsonfile(
+            options.migration_authorization_file_path)
+        # Require at least one signature
+        if len(migration_authorization.signatures) == 0:
+            raise RuntimeError("At least one signature is needed to "
+                               "perform a DB migration")
+        # Perform conversions
+        source_mre = bytes.fromhex(migration_authorization.migration_spec.exporter)
+        destination_mre = bytes.fromhex(migration_authorization.migration_spec.importer)
+        signatures = list(map(
+            lambda s: bytes.fromhex(s),
+            migration_authorization.signatures))
+    except Exception as e:
+        raise AdminError(f"While loading the migration authorization file: {str(e)}")
+
+    # Attempt to unlock the source device
+    try:
+        do_unlock(options, label=False)
+    except Exception as e:
+        raise AdminError(f"Failed to unlock device: {str(e)}")
+
+    # DB migration
+    info("Migrating DB... ", options.verbose)
+    try:
+        hsm_src = get_hsm(options.verbose)
+        hsm_dst = get_sgx_hsm(
+            options.destination_sgx_host,
+            options.destination_sgx_port,
+            options.verbose)
+
+        info("Sending source spec...", nl=False)
+        hsm_src.migrate_db_spec(
+            SgxUpgradeRoles.EXPORTER, source_mre, destination_mre, signatures)
+        info("OK")
+        info("Sending destination spec...", nl=False)
+        hsm_dst.migrate_db_spec(
+            SgxUpgradeRoles.IMPORTER, source_mre, destination_mre, signatures)
+        info("OK")
+
+        info("Getting source evidence...", nl=False)
+        src_evidence = hsm_src.migrate_db_get_evidence()
+        info(f"OK. Got {len(src_evidence)} bytes")
+        info("Getting destination evidence...", nl=False)
+        dst_evidence = hsm_dst.migrate_db_get_evidence()
+        info(f"OK. Got {len(dst_evidence)} bytes")
+
+        info("Sending destination evidence to source...", nl=False)
+        hsm_src.migrate_db_send_evidence(dst_evidence)
+        info("OK")
+        info("Sending source evidence to destination...", nl=False)
+        hsm_dst.migrate_db_send_evidence(src_evidence)
+        info("OK")
+
+        info("Getting data from source...", nl=False)
+        migration_data = hsm_src.migrate_db_get_data()
+        info("OK")
+        info("Sending data to destination...", nl=False)
+        hsm_dst.migrate_db_send_data(migration_data)
+        info("OK")
+    except Exception as e:
+        raise AdminError(f"Failed to migrate DB: {str(e)}")
+    finally:
+        dispose_hsm(hsm_src)
+        dispose_hsm(hsm_dst)
+
+    info("DB migrated successfully")

--- a/middleware/admin/misc.py
+++ b/middleware/admin/misc.py
@@ -79,10 +79,17 @@ def get_hsm(debug):
     if Platform.is_ledger():
         hsm = HSM2Dongle(debug)
     elif Platform.is_sgx():
-        hsm = HSM2DongleSGX(Platform.options("sgx_host"),
-                            Platform.options("sgx_port"), debug)
+        hsm = get_sgx_hsm(Platform.options("sgx_host"),
+                          Platform.options("sgx_port"), debug)
     else:
         raise AdminError("Platform not set or unknown platform")
+    hsm.connect()
+    info("OK")
+    return hsm
+
+
+def get_sgx_hsm(host, port, debug):
+    hsm = HSM2DongleSGX(host, port, debug)
     hsm.connect()
     info("OK")
     return hsm
@@ -132,7 +139,9 @@ def ask_for_pin(any_pin):
 
 
 def wait_for_reconnection():
-    time.sleep(SIGNER_WAIT_TIME)
+    # This is only ever needed for Ledger
+    if Platform.is_ledger():
+        time.sleep(SIGNER_WAIT_TIME)
 
 
 def get_ud_value_for_attestation(user_provided_ud_source):

--- a/middleware/tests/admin/test_migrate_db.py
+++ b/middleware/tests/admin/test_migrate_db.py
@@ -1,0 +1,418 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021 RSK Labs Ltd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import Mock, patch, call
+from admin.migrate_db import do_migrate_db
+from admin.misc import AdminError
+
+
+@patch("sys.stdout")
+@patch("admin.migrate_db.do_unlock")
+@patch("admin.migrate_db.get_hsm")
+@patch("admin.migrate_db.get_sgx_hsm")
+@patch("admin.migrate_db.dispose_hsm")
+@patch("admin.migrate_db.SGXMigrationAuthorization")
+class TestMigrateDb(TestCase):
+    def setUp(self):
+        options = SimpleNamespace()
+        options.no_unlock = False
+        options.verbose = "is-verbose"
+        options.destination_sgx_host = "sgx-host"
+        options.destination_sgx_port = 2345
+        options.migration_authorization_file_path = "a-migauth-path"
+        self.options = options
+
+    def setupMocks(self, sgx_migration_authorization, dispose_hsm, get_sgx_hsm,
+                   get_hsm, do_unlock):
+        self.dispose_hsm = dispose_hsm
+        self.get_sgx_hsm = get_sgx_hsm
+        self.get_hsm = get_hsm
+        self.do_unlock = do_unlock
+        self.sgx_migration_authorization = sgx_migration_authorization
+
+        self.src_hsm = Mock()
+        self.dst_hsm = Mock()
+
+        mig_spec = Mock()
+        mig_spec.exporter = "aa"*32
+        mig_spec.importer = "bb"*32
+        self.sgx_migration_authorization_inst = Mock()
+        self.sgx_migration_authorization_inst.migration_spec = mig_spec
+        self.sgx_migration_authorization_inst.signatures = \
+            ["7369672d6f6e65", "7369672d74776f", "7369672d7468726565"]
+        self.sgx_migration_authorization.from_jsonfile.return_value = \
+            self.sgx_migration_authorization_inst
+
+        self.src_hsm.migrate_db_get_evidence.return_value = b"the source evidence"
+        self.dst_hsm.migrate_db_get_evidence.return_value = b"the destination evidence"
+        self.src_hsm.migrate_db_get_data.return_value = b"the source data"
+
+        get_hsm.return_value = self.src_hsm
+        get_sgx_hsm.return_value = self.dst_hsm
+
+    def assert_disposed_hsms(self):
+        self.assertEqual(2, self.dispose_hsm.call_count)
+        self.assertEqual(call(self.src_hsm), self.dispose_hsm.call_args_list[0])
+        self.assertEqual(call(self.dst_hsm), self.dispose_hsm.call_args_list[1])
+
+    def test_ok(self, *args):
+        self.setupMocks(*args[:-1])
+
+        do_migrate_db(self.options)
+
+        self.do_unlock.assert_called_with(self.options, label=False)
+        self.get_hsm.assert_called_with("is-verbose")
+        self.get_sgx_hsm.assert_called_with("sgx-host", 2345, "is-verbose")
+
+        self.sgx_migration_authorization.from_jsonfile.assert_called_with(
+            "a-migauth-path")
+
+        self.src_hsm.migrate_db_spec.assert_called_with(
+            0x01,
+            bytes.fromhex("aa"*32),
+            bytes.fromhex("bb"*32),
+            [b"sig-one", b"sig-two", b"sig-three"])
+        self.dst_hsm.migrate_db_spec.assert_called_with(
+            0x02,
+            bytes.fromhex("aa"*32),
+            bytes.fromhex("bb"*32),
+            [b"sig-one", b"sig-two", b"sig-three"])
+
+        self.src_hsm.migrate_db_get_evidence.assert_called()
+        self.dst_hsm.migrate_db_get_evidence.assert_called()
+
+        self.src_hsm.migrate_db_send_evidence.assert_called_with(
+            b"the destination evidence")
+        self.dst_hsm.migrate_db_send_evidence.assert_called_with(
+            b"the source evidence")
+
+        self.src_hsm.migrate_db_get_data.assert_called()
+        self.dst_hsm.migrate_db_send_data.assert_called_with(b"the source data")
+
+        self.assert_disposed_hsms()
+
+    def test_no_migauth(self, *args):
+        self.setupMocks(*args[:-1])
+
+        self.options.migration_authorization_file_path = None
+
+        with self.assertRaises(AdminError) as e:
+            do_migrate_db(self.options)
+
+        self.assertIn("file path given", e.exception.args[0])
+
+        self.sgx_migration_authorization.from_jsonfile.assert_not_called()
+        self.do_unlock.assert_not_called()
+        self.get_hsm.assert_not_called()
+        self.get_sgx_hsm.assert_not_called()
+
+    def test_migauth_load_fails(self, *args):
+        self.setupMocks(*args[:-1])
+
+        self.sgx_migration_authorization.from_jsonfile.side_effect = \
+            Exception("json made a boo boo")
+
+        with self.assertRaises(AdminError) as e:
+            do_migrate_db(self.options)
+
+        self.assertIn("json made a boo boo", e.exception.args[0])
+
+        self.sgx_migration_authorization.from_jsonfile.assert_called_with(
+            "a-migauth-path")
+        self.do_unlock.assert_not_called()
+        self.get_hsm.assert_not_called()
+        self.get_sgx_hsm.assert_not_called()
+
+    def test_migauth_no_sigs(self, *args):
+        self.setupMocks(*args[:-1])
+
+        self.sgx_migration_authorization_inst.signatures = []
+
+        with self.assertRaises(AdminError) as e:
+            do_migrate_db(self.options)
+
+        self.assertIn("At least one signature", e.exception.args[0])
+
+        self.sgx_migration_authorization.from_jsonfile.assert_called_with(
+            "a-migauth-path")
+        self.do_unlock.assert_not_called()
+        self.get_hsm.assert_not_called()
+        self.get_sgx_hsm.assert_not_called()
+
+    def test_migauth_invalid_exporter(self, *args):
+        self.setupMocks(*args[:-1])
+
+        self.sgx_migration_authorization_inst.migration_spec.exporter = "not-hex"
+
+        with self.assertRaises(AdminError) as e:
+            do_migrate_db(self.options)
+
+        self.assertIn("non-hexadecimal", e.exception.args[0])
+
+        self.sgx_migration_authorization.from_jsonfile.assert_called_with(
+            "a-migauth-path")
+        self.do_unlock.assert_not_called()
+        self.get_hsm.assert_not_called()
+        self.get_sgx_hsm.assert_not_called()
+
+    def test_migauth_invalid_importer(self, *args):
+        self.setupMocks(*args[:-1])
+
+        self.sgx_migration_authorization_inst.migration_spec.importer = "not-hex"
+
+        with self.assertRaises(AdminError) as e:
+            do_migrate_db(self.options)
+
+        self.assertIn("non-hexadecimal", e.exception.args[0])
+
+        self.sgx_migration_authorization.from_jsonfile.assert_called_with(
+            "a-migauth-path")
+        self.do_unlock.assert_not_called()
+        self.get_hsm.assert_not_called()
+        self.get_sgx_hsm.assert_not_called()
+
+    def test_migauth_invalid_signature(self, *args):
+        self.setupMocks(*args[:-1])
+
+        self.sgx_migration_authorization_inst.signatures.append("not-hex")
+
+        with self.assertRaises(AdminError) as e:
+            do_migrate_db(self.options)
+
+        self.assertIn("non-hexadecimal", e.exception.args[0])
+
+        self.sgx_migration_authorization.from_jsonfile.assert_called_with(
+            "a-migauth-path")
+        self.do_unlock.assert_not_called()
+        self.get_hsm.assert_not_called()
+        self.get_sgx_hsm.assert_not_called()
+
+    def test_unlock_fails(self, *args):
+        self.setupMocks(*args[:-1])
+
+        self.do_unlock.side_effect = RuntimeError("unlock boo boo")
+
+        with self.assertRaises(AdminError) as e:
+            do_migrate_db(self.options)
+
+        self.assertIn("unlock device", e.exception.args[0])
+        self.assertIn("boo boo", e.exception.args[0])
+
+        self.sgx_migration_authorization.from_jsonfile.assert_called_with(
+            "a-migauth-path")
+        self.get_hsm.assert_not_called()
+        self.get_sgx_hsm.assert_not_called()
+
+    def test_spec_fails(self, *args):
+        self.setupMocks(*args[:-1])
+
+        self.dst_hsm.migrate_db_spec.side_effect = RuntimeError("wrong spec")
+
+        with self.assertRaises(AdminError) as e:
+            do_migrate_db(self.options)
+
+        self.assertIn("Failed to migrate DB", e.exception.args[0])
+        self.assertIn("wrong spec", e.exception.args[0])
+
+        self.sgx_migration_authorization.from_jsonfile.assert_called_with(
+            "a-migauth-path")
+        self.do_unlock.assert_called_with(self.options, label=False)
+        self.get_hsm.assert_called_with("is-verbose")
+        self.get_sgx_hsm.assert_called_with("sgx-host", 2345, "is-verbose")
+
+        self.src_hsm.migrate_db_spec.assert_called_with(
+            0x01,
+            bytes.fromhex("aa"*32),
+            bytes.fromhex("bb"*32),
+            [b"sig-one", b"sig-two", b"sig-three"])
+        self.dst_hsm.migrate_db_spec.assert_called_with(
+            0x02,
+            bytes.fromhex("aa"*32),
+            bytes.fromhex("bb"*32),
+            [b"sig-one", b"sig-two", b"sig-three"])
+
+        self.src_hsm.migrate_db_get_evidence.assert_not_called()
+        self.dst_hsm.migrate_db_get_evidence.assert_not_called()
+        self.src_hsm.migrate_db_send_evidence.assert_not_called()
+        self.dst_hsm.migrate_db_send_evidence.assert_not_called()
+        self.src_hsm.migrate_db_get_data.assert_not_called()
+        self.dst_hsm.migrate_db_send_data.assert_not_called()
+
+        self.assert_disposed_hsms()
+
+    def test_get_evidence_fails(self, *args):
+        self.setupMocks(*args[:-1])
+
+        self.src_hsm.migrate_db_get_evidence.side_effect = \
+            RuntimeError("evidence no no")
+
+        with self.assertRaises(AdminError) as e:
+            do_migrate_db(self.options)
+
+        self.assertIn("Failed to migrate DB", e.exception.args[0])
+        self.assertIn("evidence no no", e.exception.args[0])
+
+        self.sgx_migration_authorization.from_jsonfile.assert_called_with(
+            "a-migauth-path")
+        self.do_unlock.assert_called_with(self.options, label=False)
+        self.get_hsm.assert_called_with("is-verbose")
+        self.get_sgx_hsm.assert_called_with("sgx-host", 2345, "is-verbose")
+
+        self.src_hsm.migrate_db_spec.assert_called_with(
+            0x01,
+            bytes.fromhex("aa"*32),
+            bytes.fromhex("bb"*32),
+            [b"sig-one", b"sig-two", b"sig-three"])
+        self.dst_hsm.migrate_db_spec.assert_called_with(
+            0x02,
+            bytes.fromhex("aa"*32),
+            bytes.fromhex("bb"*32),
+            [b"sig-one", b"sig-two", b"sig-three"])
+
+        self.src_hsm.migrate_db_get_evidence.assert_called()
+        self.dst_hsm.migrate_db_get_evidence.assert_not_called()
+        self.src_hsm.migrate_db_send_evidence.assert_not_called()
+        self.dst_hsm.migrate_db_send_evidence.assert_not_called()
+        self.src_hsm.migrate_db_get_data.assert_not_called()
+        self.dst_hsm.migrate_db_send_data.assert_not_called()
+
+        self.assert_disposed_hsms()
+
+    def test_send_evidence_fails(self, *args):
+        self.setupMocks(*args[:-1])
+
+        self.dst_hsm.migrate_db_send_evidence.side_effect = \
+            RuntimeError("sending bad bad")
+
+        with self.assertRaises(AdminError) as e:
+            do_migrate_db(self.options)
+
+        self.assertIn("Failed to migrate DB", e.exception.args[0])
+        self.assertIn("sending bad bad", e.exception.args[0])
+
+        self.sgx_migration_authorization.from_jsonfile.assert_called_with(
+            "a-migauth-path")
+        self.do_unlock.assert_called_with(self.options, label=False)
+        self.get_hsm.assert_called_with("is-verbose")
+        self.get_sgx_hsm.assert_called_with("sgx-host", 2345, "is-verbose")
+
+        self.src_hsm.migrate_db_spec.assert_called_with(
+            0x01,
+            bytes.fromhex("aa"*32),
+            bytes.fromhex("bb"*32),
+            [b"sig-one", b"sig-two", b"sig-three"])
+        self.dst_hsm.migrate_db_spec.assert_called_with(
+            0x02,
+            bytes.fromhex("aa"*32),
+            bytes.fromhex("bb"*32),
+            [b"sig-one", b"sig-two", b"sig-three"])
+
+        self.src_hsm.migrate_db_get_evidence.assert_called()
+        self.dst_hsm.migrate_db_get_evidence.assert_called()
+        self.src_hsm.migrate_db_send_evidence.assert_called_with(
+            b"the destination evidence")
+        self.dst_hsm.migrate_db_send_evidence.assert_called_with(
+            b"the source evidence")
+        self.src_hsm.migrate_db_get_data.assert_not_called()
+        self.dst_hsm.migrate_db_send_data.assert_not_called()
+
+        self.assert_disposed_hsms()
+
+    def test_get_data_fails(self, *args):
+        self.setupMocks(*args[:-1])
+
+        self.src_hsm.migrate_db_get_data.side_effect = RuntimeError("data nana")
+
+        with self.assertRaises(AdminError) as e:
+            do_migrate_db(self.options)
+
+        self.assertIn("Failed to migrate DB", e.exception.args[0])
+        self.assertIn("data nana", e.exception.args[0])
+
+        self.sgx_migration_authorization.from_jsonfile.assert_called_with(
+            "a-migauth-path")
+        self.do_unlock.assert_called_with(self.options, label=False)
+        self.get_hsm.assert_called_with("is-verbose")
+        self.get_sgx_hsm.assert_called_with("sgx-host", 2345, "is-verbose")
+
+        self.src_hsm.migrate_db_spec.assert_called_with(
+            0x01,
+            bytes.fromhex("aa"*32),
+            bytes.fromhex("bb"*32),
+            [b"sig-one", b"sig-two", b"sig-three"])
+        self.dst_hsm.migrate_db_spec.assert_called_with(
+            0x02,
+            bytes.fromhex("aa"*32),
+            bytes.fromhex("bb"*32),
+            [b"sig-one", b"sig-two", b"sig-three"])
+
+        self.src_hsm.migrate_db_get_evidence.assert_called()
+        self.dst_hsm.migrate_db_get_evidence.assert_called()
+        self.src_hsm.migrate_db_send_evidence.assert_called_with(
+            b"the destination evidence")
+        self.dst_hsm.migrate_db_send_evidence.assert_called_with(
+            b"the source evidence")
+        self.src_hsm.migrate_db_get_data.assert_called()
+        self.dst_hsm.migrate_db_send_data.assert_not_called()
+
+        self.assert_disposed_hsms()
+
+    def test_send_data_fails(self, *args):
+        self.setupMocks(*args[:-1])
+
+        self.dst_hsm.migrate_db_send_data.side_effect = RuntimeError("import boo boo")
+
+        with self.assertRaises(AdminError) as e:
+            do_migrate_db(self.options)
+
+        self.assertIn("Failed to migrate DB", e.exception.args[0])
+        self.assertIn("import boo boo", e.exception.args[0])
+
+        self.sgx_migration_authorization.from_jsonfile.assert_called_with(
+            "a-migauth-path")
+        self.do_unlock.assert_called_with(self.options, label=False)
+        self.get_hsm.assert_called_with("is-verbose")
+        self.get_sgx_hsm.assert_called_with("sgx-host", 2345, "is-verbose")
+
+        self.src_hsm.migrate_db_spec.assert_called_with(
+            0x01,
+            bytes.fromhex("aa"*32),
+            bytes.fromhex("bb"*32),
+            [b"sig-one", b"sig-two", b"sig-three"])
+        self.dst_hsm.migrate_db_spec.assert_called_with(
+            0x02,
+            bytes.fromhex("aa"*32),
+            bytes.fromhex("bb"*32),
+            [b"sig-one", b"sig-two", b"sig-three"])
+
+        self.src_hsm.migrate_db_get_evidence.assert_called()
+        self.dst_hsm.migrate_db_get_evidence.assert_called()
+        self.src_hsm.migrate_db_send_evidence.assert_called_with(
+            b"the destination evidence")
+        self.dst_hsm.migrate_db_send_evidence.assert_called_with(
+            b"the source evidence")
+        self.src_hsm.migrate_db_get_data.assert_called()
+        self.dst_hsm.migrate_db_send_data.assert_called_with(b"the source data")
+
+        self.assert_disposed_hsms()

--- a/middleware/tests/sgx/test_hsm2dongle.py
+++ b/middleware/tests/sgx/test_hsm2dongle.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, call
 from sgx.hsm2dongle import HSM2DongleSGX
 from ledger.hsm2dongle import HSM2DongleError
 
@@ -47,6 +47,12 @@ class TestHSM2DongleSGX(TestCase):
 
     def assert_exchange_called(self, bs):
         self.dongle.exchange.assert_called_with(bs, timeout=self.EXPECTED_DONGLE_TIMEOUT)
+
+    def assert_xchg_called_ith(self, i, bs):
+        self.assertGreaterEqual(self.dongle.exchange.call_count, i+1)
+        self.assertEqual(
+            call(bs, timeout=self.EXPECTED_DONGLE_TIMEOUT),
+            self.dongle.exchange.call_args_list[i], f"Call #{i} mismatch")
 
     def test_echo_ok(self):
         self.dongle.exchange.return_value = bytes([0x80, 0xA4, 0x41, 0x42, 0x43])
@@ -139,3 +145,212 @@ class TestHSM2DongleSGX(TestCase):
         self.assert_exchange_called(bytes([0x80, 0xA0, 0x00]) +
                                     bytes.fromhex("aa"*32) +
                                     b"12345678")
+
+    def test_migrate_db_spec_ok(self):
+        self.dongle.exchange.side_effect = [
+            bytes([0xAA, 0xBB, 0xCC]),
+            bytes([0xAA, 0xBB, 0x01]),
+            bytes([0xAA, 0xBB, 0x01]),
+            bytes([0xAA, 0xBB, 0x00]),
+        ]
+
+        self.hsm2dongle.migrate_db_spec(
+            0x12, b"a"*5, b"b"*5,
+            [b"c"*10, b"d"*10, b"e"*10])
+
+        self.assertEqual(4, self.dongle.exchange.call_count)
+        self.assert_xchg_called_ith(0, bytes([0x80, 0xA6, 0x01, 0x12]) + b"aaaaabbbbb")
+        self.assert_xchg_called_ith(1, bytes([0x80, 0xA6, 0x02]) + b"cccccccccc")
+        self.assert_xchg_called_ith(2, bytes([0x80, 0xA6, 0x02]) + b"dddddddddd")
+        self.assert_xchg_called_ith(3, bytes([0x80, 0xA6, 0x02]) + b"eeeeeeeeee")
+
+    def test_migrate_db_spec_notenough_sigs(self):
+        self.dongle.exchange.side_effect = [
+            bytes([0xAA, 0xBB, 0xCC]),
+            bytes([0xAA, 0xBB, 0x01]),
+            bytes([0xAA, 0xBB, 0x01]),
+        ]
+
+        with self.assertRaises(HSM2DongleError) as e:
+            self.hsm2dongle.migrate_db_spec(
+                0x12, b"a"*5, b"b"*5,
+                [b"c"*10, b"d"*10])
+
+        self.assertIn("signatures gathered", e.exception.message)
+
+        self.assertEqual(3, self.dongle.exchange.call_count)
+        self.assert_xchg_called_ith(0, bytes([0x80, 0xA6, 0x01, 0x12]) + b"aaaaabbbbb")
+        self.assert_xchg_called_ith(1, bytes([0x80, 0xA6, 0x02]) + b"cccccccccc")
+        self.assert_xchg_called_ith(2, bytes([0x80, 0xA6, 0x02]) + b"dddddddddd")
+
+    def test_migrate_db_spec_err_raised(self):
+        self.dongle.exchange.side_effect = [
+            bytes([0xAA, 0xBB, 0xCC]),
+            HSM2DongleError("something happened"),
+        ]
+
+        with self.assertRaises(HSM2DongleError) as e:
+            self.hsm2dongle.migrate_db_spec(
+                0x12, b"a"*5, b"b"*5,
+                [b"c"*10, b"d"*10])
+
+        self.assertIn("something happened", e.exception.message)
+
+        self.assertEqual(2, self.dongle.exchange.call_count)
+        self.assert_xchg_called_ith(0, bytes([0x80, 0xA6, 0x01, 0x12]) + b"aaaaabbbbb")
+        self.assert_xchg_called_ith(1, bytes([0x80, 0xA6, 0x02]) + b"cccccccccc")
+
+    def test_migrate_db_get_evidence_ok(self):
+        self.dongle.exchange.side_effect = [
+            bytes([0xAA, 0xBB, 0x01]) + b"a"*3,
+            bytes([0xAA, 0xBB, 0x01]) + b"b"*5,
+            bytes([0xAA, 0xBB, 0x00]) + b"c"*7,
+        ]
+
+        self.assertEqual(b"aaabbbbbccccccc", self.hsm2dongle.migrate_db_get_evidence())
+
+        self.assertEqual(3, self.dongle.exchange.call_count)
+        for i in [0, 1, 2]:
+            self.assert_xchg_called_ith(i, bytes([0x80, 0xA6, 0x03]))
+
+    def test_migrate_db_get_evidence_err_raised(self):
+        self.dongle.exchange.side_effect = [
+            bytes([0xAA, 0xBB, 0x01]) + b"a"*3,
+            HSM2DongleError("oopsies"),
+        ]
+
+        with self.assertRaises(HSM2DongleError) as e:
+            self.hsm2dongle.migrate_db_get_evidence()
+
+        self.assertIn("oopsies", e.exception.message)
+
+        self.assertEqual(2, self.dongle.exchange.call_count)
+        for i in [0, 1]:
+            self.assert_xchg_called_ith(i, bytes([0x80, 0xA6, 0x03]))
+
+    def test_migrate_db_send_evidence_ok(self):
+        self.dongle.exchange.side_effect = [
+            bytes([0xAA, 0xBB, 0x01]),
+            bytes([0xAA, 0xBB, 0x01]),
+            bytes([0xAA, 0xBB, 0x01]),
+            bytes([0xAA, 0xBB, 0x01]),
+            bytes([0xAA, 0xBB, 0x01]),
+            bytes([0xAA, 0xBB, 0x01]),
+            bytes([0xAA, 0xBB, 0x00]),
+        ]
+
+        self.hsm2dongle.migrate_db_send_evidence(
+            b"1"*80 +
+            b"2"*80 +
+            b"3"*80 +
+            b"4"*80 +
+            b"5"*80 +
+            b"6"*80 +
+            b"7"*56
+        )
+
+        self.assertEqual(7, self.dongle.exchange.call_count)
+        self.assert_xchg_called_ith(0, bytes([0x80, 0xA6, 0x04, 0x02, 0x18]) + b"1"*80)
+        self.assert_xchg_called_ith(1, bytes([0x80, 0xA6, 0x04]) + b"2"*80)
+        self.assert_xchg_called_ith(2, bytes([0x80, 0xA6, 0x04]) + b"3"*80)
+        self.assert_xchg_called_ith(3, bytes([0x80, 0xA6, 0x04]) + b"4"*80)
+        self.assert_xchg_called_ith(4, bytes([0x80, 0xA6, 0x04]) + b"5"*80)
+        self.assert_xchg_called_ith(5, bytes([0x80, 0xA6, 0x04]) + b"6"*80)
+        self.assert_xchg_called_ith(6, bytes([0x80, 0xA6, 0x04]) + b"7"*56)
+
+    def test_migrate_db_send_evidence_noack(self):
+        self.dongle.exchange.side_effect = [
+            bytes([0xAA, 0xBB, 0x01]),
+            bytes([0xAA, 0xBB, 0x01]),
+            bytes([0xAA, 0xBB, 0x01]),
+        ]
+
+        with self.assertRaises(HSM2DongleError) as e:
+            self.hsm2dongle.migrate_db_send_evidence(
+                b"1"*80 +
+                b"2"*80 +
+                b"3"*67
+            )
+
+        self.assertIn("evidence ack", e.exception.message)
+
+        self.assertEqual(3, self.dongle.exchange.call_count)
+        self.assert_xchg_called_ith(0, bytes([0x80, 0xA6, 0x04, 0x00, 0xe3]) + b"1"*80)
+        self.assert_xchg_called_ith(1, bytes([0x80, 0xA6, 0x04]) + b"2"*80)
+        self.assert_xchg_called_ith(2, bytes([0x80, 0xA6, 0x04]) + b"3"*67)
+
+    def test_migrate_db_send_evidence_err_raised(self):
+        self.dongle.exchange.side_effect = [
+            bytes([0xAA, 0xBB, 0x01]),
+            bytes([0xAA, 0xBB, 0x01]),
+            HSM2DongleError("sgx made a boo boo")
+        ]
+
+        with self.assertRaises(HSM2DongleError) as e:
+            self.hsm2dongle.migrate_db_send_evidence(
+                b"1"*40 +
+                b"2"*40 +
+                b"3"*1280
+            )
+
+        self.assertIn("boo boo", e.exception.message)
+
+        self.assertEqual(3, self.dongle.exchange.call_count)
+        self.assert_xchg_called_ith(
+            0, bytes([0x80, 0xA6, 0x04, 0x05, 0x50]) + b"1"*40 + b"2"*40)
+        self.assert_xchg_called_ith(
+            1, bytes([0x80, 0xA6, 0x04]) + b"3"*80)
+        self.assert_xchg_called_ith(
+            2, bytes([0x80, 0xA6, 0x04]) + b"3"*80)
+
+    def test_migrate_db_get_data_ok(self):
+        self.dongle.exchange.return_value = \
+            bytes([0xAA, 0xBB, 0xCC]) + b"0123456789abcdef"
+
+        self.assertEqual(b"0123456789abcdef", self.hsm2dongle.migrate_db_get_data())
+
+        self.assertEqual(1, self.dongle.exchange.call_count)
+        self.assert_xchg_called_ith(0, bytes([0x80, 0xA6, 0x05]))
+
+    def test_migrate_db_get_data_nodata(self):
+        self.dongle.exchange.return_value = bytes([0xAA, 0xBB, 0xCC])
+
+        with self.assertRaises(HSM2DongleError) as e:
+            self.hsm2dongle.migrate_db_get_data()
+
+        self.assertIn("data gathering failed", e.exception.message)
+
+        self.assertEqual(1, self.dongle.exchange.call_count)
+        self.assert_xchg_called_ith(0, bytes([0x80, 0xA6, 0x05]))
+
+    def test_migrate_db_get_data_err_raised(self):
+        self.dongle.exchange.side_effect = HSM2DongleError("migration nana")
+
+        with self.assertRaises(HSM2DongleError) as e:
+            self.hsm2dongle.migrate_db_get_data()
+
+        self.assertIn("migration nana", e.exception.message)
+
+        self.assertEqual(1, self.dongle.exchange.call_count)
+        self.assert_xchg_called_ith(0, bytes([0x80, 0xA6, 0x05]))
+
+    def test_migrate_db_send_data_ok(self):
+        self.dongle.exchange.return_value = bytes([0xAA, 0xBB, 0xCC])
+
+        self.hsm2dongle.migrate_db_send_data(b"aabbccddeeff44556677")
+
+        self.assertEqual(1, self.dongle.exchange.call_count)
+        self.assert_xchg_called_ith(
+            0, bytes([0x80, 0xA6, 0x05]) + b"aabbccddeeff44556677")
+
+    def test_migrate_db_send_data_err_raised(self):
+        self.dongle.exchange.side_effect = HSM2DongleError("data bad bad")
+
+        with self.assertRaises(HSM2DongleError) as e:
+            self.hsm2dongle.migrate_db_send_data(b"aabbccddeeff44556677")
+
+        self.assertIn("bad bad", e.exception.message)
+
+        self.assertEqual(1, self.dongle.exchange.call_count)
+        self.assert_xchg_called_ith(
+            0, bytes([0x80, 0xA6, 0x05]) + b"aabbccddeeff44556677")


### PR DESCRIPTION
- Added new `migrate_db` operation to `adm_sgx` tool
- Added supporting operations in `HSM2DongleSGX`
- Added helper function for getting an sgx hsm proxy to misc library
- Added `migrate_db` operation unit tests
- Added `HSM2DongleSGX.migrate_db_*` unit tests
- Fixed failing unit tests