### PR TITLE
SGX upgrade script and distribution

### DIFF
--- a/dist/common/scripts/print_utils
+++ b/dist/common/scripts/print_utils
@@ -27,14 +27,14 @@ else
     txtrst=""
 fi
 
-function print_info() {
+print_info() {
     echo "${txtgrn}$1${txtrst}"
 }
 
-function print_warning() {
+print_warning() {
     echo "${txtylw}$1${txtrst}"
 }
 
-function print_error() {
+print_error() {
     echo "${txtred}$1${txtrst}"
 }

--- a/dist/sgx/hsm/start
+++ b/dist/sgx/hsm/start
@@ -14,11 +14,11 @@ docker build -t $DOCKER_IMAGE $BINDIR $QUIET
 echo -e "\e[96mDocker image build done.\e[0m"
 echo
 
-DOCKER_CNT=powhsmsgx-runner
+DOCKER_CNT="powhsmsgx-runner$POWHSM_UPGRADE_SUFFIX"
 DOCKER_USER="$(id -u):$(id -g)"
-HOSTNAME="powhsmsgx"
+HOSTNAME="powhsmsgx$POWHSM_UPGRADE_SUFFIX"
 NETWORK=powhsmsgx_net
-PORT=7777
+PORT=${POWHSM_UPGRADE_PORT:-7777}
 DOCKER_PORT="$PORT:$PORT"
 SGX_PRV_GID=$(getent group sgx_prv | cut -d: -f3)
 

--- a/dist/sgx/hsm/stop
+++ b/dist/sgx/hsm/stop
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-DOCKER_CNT=powhsmsgx-runner
+DOCKER_CNT="powhsmsgx-runner$POWHSM_UPGRADE_SUFFIX"
 docker stop $DOCKER_CNT

--- a/dist/sgx/scripts/attest
+++ b/dist/sgx/scripts/attest
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+ROOT_DIR=$(realpath $(dirname $0)/..)
+source $ROOT_DIR/scripts/print_utils
+
+# The admin command used to interact with the powhsmsgx service
+ADMIN_CMD="$ROOT_DIR/bin/adm_sgx/adm_sgx --host powhsmsgx"
+
+# Directory where attesting result will be saved
+EXPORT_DIR="$ROOT_DIR/export"
+PUBLIC_KEY_FILE="$EXPORT_DIR/public-keys.txt"
+PUBLIC_KEY_FILE_JSON="$EXPORT_DIR/public-keys.json"
+ATTESTATION_FILE="$EXPORT_DIR/attestation.json"
+
+# File with the current pin
+PIN_FILE="$ROOT_DIR/pin.txt"
+
+error() {
+    if [[ $? -ne 0 ]]; then
+        rm -rf $EXPORT_DIR
+        exit 1
+    fi
+}
+
+createOutputDir() {
+    rm -rf $EXPORT_DIR
+    mkdir -p $EXPORT_DIR
+    error
+}
+
+attestation() {
+    $ADMIN_CMD attestation -P$(cat $PIN_FILE) -o $ATTESTATION_FILE
+    error
+}
+
+keys() {
+    $ADMIN_CMD pubkeys -uo $PUBLIC_KEY_FILE
+    error
+}
+
+verify_attestation() {
+    $ADMIN_CMD verify_attestation -t $ATTESTATION_FILE -b $PUBLIC_KEY_FILE_JSON
+    error
+}
+
+print_info "Creating export directory"
+createOutputDir
+echo
+print_info "Gathering attestation"
+attestation
+echo
+print_info "Gathering public keys"
+keys
+echo
+print_info "Verifying attestation"
+verify_attestation

--- a/dist/sgx/scripts/migrate
+++ b/dist/sgx/scripts/migrate
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+ROOT_DIR=$(realpath $(dirname $0)/..)
+
+# powHSM hostnames
+POWHSM_HOST_EXP="powhsmsgx"
+POWHSM_HOST_IMP="powhsmsgx_tmp"
+
+# powHSM ports
+POWHSM_PORT_EXP="7777"
+POWHSM_PORT_IMP="3333"
+
+# Admin binary
+ADMIN_BIN=$ROOT_DIR/bin/adm_sgx/adm_sgx
+
+# File with the current pin
+PIN_FILE="$ROOT_DIR/pin.txt"
+
+# Migration authorization file
+MIG_AUTH_FILE="$ROOT_DIR/hsm/migration_auth.json"
+
+$ADMIN_BIN migrate_db \
+    --host $POWHSM_HOST_EXP --port $POWHSM_PORT_EXP \
+    -P$(cat $PIN_FILE) \
+    --dest-host $POWHSM_HOST_IMP --dest-port $POWHSM_PORT_IMP \
+    --migauth $MIG_AUTH_FILE
+exit $?

--- a/dist/sgx/upgrade-existing-powhsm
+++ b/dist/sgx/upgrade-existing-powhsm
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+ROOT_DIR=$(realpath $(dirname $0))
+source $ROOT_DIR/scripts/print_utils
+
+# Require superuser, since we need to update a service in the host
+if ! [ "$(id -u)" == "0" ]; then
+    print_info "Please run with sudo."
+    exit 1
+fi
+
+SERVICE_NAME=powhsmsgx
+HSMBIN_DIR=$ROOT_DIR/hsm
+MIGRATION_DIR=$ROOT_DIR/tmpinstall
+
+# Middleware binaries
+ADMIN_DIR="$ROOT_DIR/bin/adm_sgx"
+ADMIN_BUNDLE="$ADMIN_DIR.tgz"
+ADMIN_BIN="$ADMIN_DIR/adm_sgx"
+
+# File with the current pin
+PIN_FILE="$ROOT_DIR/pin.txt"
+PIN_FILE_BASE=$(basename $PIN_FILE)
+
+# Migration authorization file
+MIG_AUTH_FILE="$HSMBIN_DIR/migration_auth.json"
+
+cleanup() {
+	if [[ -d $ADMIN_DIR ]]; then
+		rm -rf $ADMIN_DIR
+	fi
+	if [[ -d $MIGRATION_DIR ]]; then
+		rm -rf $MIGRATION_DIR
+	fi
+}
+
+error() {
+    if [[ $? -ne 0 ]]; then
+        cleanup
+        print_error "$1"
+        exit 1
+    fi
+}
+
+print_info "Welcome to the SGX powHSM Setup for RSK"
+echo
+
+test -e $PIN_FILE
+error "Pin file $PIN_FILE_BASE not found."
+
+test -e $MIG_AUTH_FILE
+error "Migration authorization file $MIG_AUTH_FILE not found."
+
+print_info "Setting up tooling..."
+rm -rf $ADMIN_DIR
+error
+mkdir -p $ADMIN_DIR
+error
+tar -xzmf $ADMIN_BUNDLE -C $ADMIN_DIR
+error
+
+print_info "Searching for an existing powHSM installation..."
+systemctl status $SERVICE_NAME > /dev/null
+error "Couldn't find an existing powHSM installation."
+
+INSTALL_DIR=$(realpath $(systemctl show $SERVICE_NAME --property=WorkingDirectory | sed "s|WorkingDirectory=||g"))
+test -d $INSTALL_DIR
+error "Error grabbing the current powHSM installation directory."
+print_info "Found powHSM installed in $INSTALL_DIR"
+
+print_info "Migrating powHSM..."
+systemctl restart $SERVICE_NAME
+error "Unable to restart the service."
+mkdir -p $MIGRATION_DIR/bin
+error "Error creating destination directory."
+cp $ROOT_DIR/hsm/* $MIGRATION_DIR/bin
+error "Error copying binary files."
+cp $ROOT_DIR/Dockerfile $MIGRATION_DIR/bin
+error "Error copying docker file."
+POWHSM_UPGRADE_SUFFIX=_tmp POWHSM_UPGRADE_PORT=3333 $MIGRATION_DIR/bin/start >/dev/null 2>&1 &
+error "Error starting the powHSM."
+sleep 5
+$ROOT_DIR/scripts/run_with_docker ./scripts/migrate
+error "Error during the powHSM migration, aborting."
+POWHSM_UPGRADE_SUFFIX=_tmp $MIGRATION_DIR/bin/stop >/dev/null 2>&1
+error "Error stopping the powHSM."
+
+print_info "Updating service..."
+systemctl stop $SERVICE_NAME
+error "Unable to stop the service."
+cp -R $HSMBIN_DIR/* $INSTALL_DIR/bin
+error "Could not copy the powHSM binaries to the installation directory."
+cp -R $ROOT_DIR/Dockerfile $INSTALL_DIR/bin
+error "Could not copy the Dockerfile to the installation directory."
+rm -f $INSTALL_DIR/*.dat
+error "Could not remove the existing DB files from the installation directory."
+cp -R $MIGRATION_DIR/*.dat $INSTALL_DIR/
+error "Could not copy the new DB files to the installation directory."
+rm -rf $MIGRATION_DIR
+error "Could not remove the temporary installation directory."
+
+systemctl start $SERVICE_NAME
+error "Unable to start the service."
+
+$ROOT_DIR/scripts/run_with_docker ./scripts/attest
+error "Unable to gather powHSM upgrade attestation."
+
+systemctl restart $SERVICE_NAME
+error "Unable to restart the service."
+
+cleanup
+print_info "HSM SGX upgrade done."
+echo
+print_info "To check the status of the service, run 'systemctl status $SERVICE_NAME'."
+print_info "To follow the logs, run 'journalctl -u $SERVICE_NAME -f'."


### PR DESCRIPTION
- Added `upgrade-existing-powhsm` script that performs the upgrade process calling necessary dependant scripts
- Added `migrate` and `attest` scripts to perform migration and attestation gathering within a docker container, respectively
- Start and stop scripts now can optionally specify a different container name, hostname and port
- New files already included in current distribution building process
- Fixed unnecessary 'function' prefix used (still to be fixed on sgx setup scripts)