### PR TITLE
Fixes format-python script

### DIFF
--- a/middleware/admin/certificate_v2.py
+++ b/middleware/admin/certificate_v2.py
@@ -42,7 +42,7 @@ class HSMCertificateV2Element:
     def from_dict(cls, element_map):
         if element_map.get("type") not in cls.TYPE_MAPPING:
             raise ValueError("Invalid or missing element type for "
-                             f"element {element_map.get("name")}")
+                             f"element {element_map.get('name')}")
 
         return cls.TYPE_MAPPING[element_map["type"]](element_map)
 

--- a/middleware/admin/changepin.py
+++ b/middleware/admin/changepin.py
@@ -66,7 +66,7 @@ def do_changepin(options):
     # In Ledger, we can only change the pin while in bootloader mode
     if Platform.is_ledger() and mode != HSM2Dongle.MODE.BOOTLOADER:
         raise AdminError("Device not in bootloader mode. "
-                         f"{Platform.message("restart").capitalize()} and try again")
+                         f"{Platform.message('restart').capitalize()} and try again")
 
     # Ask the user for a new pin if one has not been given
     if new_pin is None:
@@ -80,6 +80,6 @@ def do_changepin(options):
     info("Pin changed.", nl=Platform.is_sgx())
     # We require a restart in Ledger only
     if Platform.is_ledger():
-        info(f" Please {Platform.message("restart")}.")
+        info(f" Please {Platform.message('restart')}.")
 
     dispose_hsm(hsm)

--- a/middleware/admin/onboard.py
+++ b/middleware/admin/onboard.py
@@ -73,7 +73,7 @@ def do_onboard(options):
     # Require bootloader mode for onboarding
     if mode != HSM2Dongle.MODE.BOOTLOADER:
         raise AdminError("Device not in bootloader mode. "
-                         f"{Platform.message("restart").capitalize()} and try again")
+                         f"{Platform.message('restart').capitalize()} and try again")
 
     # Echo check
     info("Sending echo... ", options.verbose)

--- a/middleware/admin/pubkeys.py
+++ b/middleware/admin/pubkeys.py
@@ -66,7 +66,7 @@ def do_get_pubkeys(options):
     # Modes for which we can't get the public keys
     if mode in [HSM2Dongle.MODE.UNKNOWN, HSM2Dongle.MODE.BOOTLOADER]:
         raise AdminError(
-            f"Device not in app mode. {Platform.message("restart").capitalize()}")
+            f"Device not in app mode. {Platform.message('restart').capitalize()}")
 
     # Gather public keys
     pubkeys = {}

--- a/middleware/admin/unlock.py
+++ b/middleware/admin/unlock.py
@@ -67,7 +67,7 @@ def do_unlock(options, exit=True, no_exec=False, label=True):
     # Modes for which we can't unlock
     if mode == HSM2Dongle.MODE.UNKNOWN:
         raise AdminError("Device mode unknown. Already unlocked? Otherwise "
-                         f"{Platform.message("restart")} and try again")
+                         f"{Platform.message('restart')} and try again")
     if mode == HSM2Dongle.MODE.SIGNER or mode == HSM2Dongle.MODE.UI_HEARTBEAT:
         raise AdminError("Device already unlocked")
 

--- a/middleware/lbutils.py
+++ b/middleware/lbutils.py
@@ -64,7 +64,7 @@ def main():
     try:
         command = sys.argv[1]
         sys.argv = [f"{sys.argv[0]} {command}"] + sys.argv[2:]
-        module = f"ledgerblue.{utilities[command]["module"]}"
+        module = f"ledgerblue.{utilities[command]['module']}"
         post_process = utilities[command]["post_process"]
 
         buffer = io.StringIO()

--- a/middleware/ledger/protocol.py
+++ b/middleware/ledger/protocol.py
@@ -74,7 +74,7 @@ class HSM2ProtocolLedger(HSM2Protocol):
             self.logger.info(
                 "Could not determine onboarded status. If unlocked, "
                 + "please enter the signing app and rerun the manager. Otherwise,"
-                + f"{Platform.message("restart")} and try again"
+                + f"{Platform.message('restart')} and try again"
             )
             raise HSM2ProtocolInterrupt()
 
@@ -197,12 +197,12 @@ class HSM2ProtocolLedger(HSM2Protocol):
                     raise Exception("Dongle reported fail to change pin. Pin invalid?")
                 self.pin.commit_change()
                 self.logger.info(
-                    f"PIN changed. Please {Platform.message("restart")}"
+                    f"PIN changed. Please {Platform.message('restart')}"
                 )
             except Exception as e:
                 self.pin.abort_change()
                 self.logger.error(
-                    f"Error changing PIN: %s. Please {Platform.message("restart")} "
+                    f"Error changing PIN: %s. Please {Platform.message('restart')} "
                     "and try again", format(e),
                 )
             finally:

--- a/middleware/tests/admin/test_verify_sgx_attestation.py
+++ b/middleware/tests/admin/test_verify_sgx_attestation.py
@@ -132,9 +132,9 @@ class TestVerifySgxAttestation(TestCase):
             "Installed powHSM MRSIGNER: 1122334455",
             "Installed powHSM version: 5.5",
             "Platform: plf",
-            f"UD value: {"aa"*32}",
-            f"Best block: {"bb"*32}",
-            f"Last transaction signed: {"cc"*8}",
+            f"UD value: {'aa'*32}",
+            f"Best block: {'bb'*32}",
+            f"Last transaction signed: {'cc'*8}",
             "Timestamp: 205",
         ], fill="-")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ exclude =
     # Pretty standard ignores
     .git,
     __pycache__,
+    venv,
     # Build output artifacts
     middleware/build/build,
     # We don't want to mess with third party stuff

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,11 +34,13 @@ statistics = True
 
 [yapf]
 based_on_style = pep8
-spaces_before_comment = 1
+spaces_before_comment = 2
 split_before_logical_operator = true
 # AKA max line length
 column_limit = 90
 continuation_align_style = space
+dedent_closing_brackets = true
+coalesce_brackets = true
 indent_width = 4
 indent_blank_lines = False
 


### PR DESCRIPTION
Fixes the error in `format-python` script by replacing nested double quotes in f-strings with single quotes. This is a [known limitation](https://github.com/google/yapf/issues/1136) of `yapf`.

Incidentally, adds `venv` folders to list of exclusions for the python linter and enhances yapf rules so that code generated by the python format script passes the python linter.