### PR TITLE
Fixes firmware and middleware coverage badges

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           aws s3 sync \
             middleware/coverage/ \
-            s3://${{ secrets.CODECOVERAGE_S3_BUCKET }}/powhsm_5.5.x/middleware_coverage_report \
+            s3://${{ secrets.CODECOVERAGE_S3_BUCKET }}/powhsm_head/middleware_coverage_report \
             --sse aws:kms --sse-kms-key-id ${{ secrets.CODECOVERAGE_KMS_KEY_ID }} \
             --no-progress --follow-symlinks --delete --only-show-errors
 
@@ -52,7 +52,7 @@ jobs:
         run: |
           aws s3 sync \
             firmware/coverage/output/ \
-            s3://${{ secrets.CODECOVERAGE_S3_BUCKET }}/powhsm_5.5.x/firmware_coverage_report \
+            s3://${{ secrets.CODECOVERAGE_S3_BUCKET }}/powhsm_head/firmware_coverage_report \
             --sse aws:kms --sse-kms-key-id ${{ secrets.CODECOVERAGE_KMS_KEY_ID }} \
             --no-progress --follow-symlinks --delete --only-show-errors
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ![Tests](https://github.com/rsksmart/rsk-powhsm/actions/workflows/run-tests.yml/badge.svg)
 ![Python linter](https://github.com/rsksmart/rsk-powhsm/actions/workflows/lint-python.yml/badge.svg)
 ![C linter](https://github.com/rsksmart/rsk-powhsm/actions/workflows/lint-c.yml/badge.svg)
-[![Middleware coverage](https://img.shields.io/endpoint?url=https://d16sboe9lzo4ru.cloudfront.net/powhsm_5.5.x/middleware_coverage_report/badge.json)](https://d16sboe9lzo4ru.cloudfront.net/powhsm_head/middleware_coverage_report/index.html)
-[![Firmware coverage](https://img.shields.io/endpoint?url=https://d16sboe9lzo4ru.cloudfront.net/powhsm_5.5.x/firmware_coverage_report/badge.json)](https://d16sboe9lzo4ru.cloudfront.net/powhsm_head/firmware_coverage_report/index.html)
+[![Middleware coverage](https://img.shields.io/endpoint?url=https://d16sboe9lzo4ru.cloudfront.net/powhsm_head/middleware_coverage_report/badge.json)](https://d16sboe9lzo4ru.cloudfront.net/powhsm_head/middleware_coverage_report/index.html)
+[![Firmware coverage](https://img.shields.io/endpoint?url=https://d16sboe9lzo4ru.cloudfront.net/powhsm_head/firmware_coverage_report/badge.json)](https://d16sboe9lzo4ru.cloudfront.net/powhsm_head/firmware_coverage_report/index.html)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 


### PR DESCRIPTION
Fixes URL for uploading/displaying firmware and middleware reports and badge to/from powhsm_head bucket instead of powhsm_5.5.x