### PR TITLE
Fix file ownership after upgrade

### DIFF
--- a/dist/sgx/upgrade-existing-powhsm
+++ b/dist/sgx/upgrade-existing-powhsm
@@ -96,6 +96,8 @@ rm -f $INSTALL_DIR/*.dat
 error "Could not remove the existing DB files from the installation directory."
 cp -R $MIGRATION_DIR/*.dat $INSTALL_DIR/
 error "Could not copy the new DB files to the installation directory."
+chown -R powhsm:powhsm $INSTALL_DIR
+error "Could not set the ownership of the installation directory."
 rm -rf $MIGRATION_DIR
 error "Could not remove the temporary installation directory."
 


### PR DESCRIPTION
Replicates the same strategy used in `dist/sgx/scripts/install_service`. The upgrade script is executed by `root` in the host machine, which results in leaving all files in the new INSTALL_DIR (including the directory itself) owned by that user. This means that the powhsm service does not have write permission to these files, since the service is executed by the `powhsm` user.

This is not a problem in the initial installation, since we explicitly change ownership in the `install_service` script. This commit replicates the same strategy to `upgrade-existing-powhsm`, ensuring that the new installation is owned by `powhsm` as well.