### PR TITLE
Using secp256k1 context randomisation

### DIFF
--- a/firmware/src/hal/sgx/src/trusted/seed.c
+++ b/firmware/src/hal/sgx/src/trusted/seed.c
@@ -47,8 +47,20 @@ static secp256k1_context* sp_ctx = NULL;
 
 bool seed_init() {
     // Init the secp256k1 context
-    if (!sp_ctx)
+    if (!sp_ctx) {
+        unsigned char randomize[32];
         sp_ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
+        if (!random_getrandom(randomize, sizeof(randomize))) {
+            LOG("Error generating random seed for "
+                "secp256k1 context randomisation\n");
+            return false;
+        }
+        if (!secp256k1_context_randomize(sp_ctx, randomize)) {
+            LOG("Error randomising secp256k1 context\n");
+            return false;
+        }
+        explicit_bzero(randomize, sizeof(randomize));
+    }
 
     memset(G_seed, 0, sizeof(G_seed));
     G_seed_available = false;

--- a/firmware/src/hal/sgx/test/bip32/test_bip32.c
+++ b/firmware/src/hal/sgx/test/bip32/test_bip32.c
@@ -59,6 +59,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
+#include <time.h>
 #include "bip32.h"
 #include "test_helpers.h"
 
@@ -347,6 +348,12 @@ static void printf_hex(uint8_t *buf, size_t len) {
     printf("\n");
 }
 
+bool random_getrandom(void *buffer, size_t length) {
+    for (size_t i = 0; i < length; i++)
+        ((uint8_t *)buffer)[i] = (uint8_t)(rand() & 0xFF);
+    return true;
+}
+
 void test_derivation() {
     uint8_t expected_bytes[SERIALISED_BIP32_KEY_LENGTH];
     uint8_t canary[CANARY_LENGTH];
@@ -418,6 +425,8 @@ void test_derivation_fails_if_output_buffer_too_small() {
 }
 
 int main() {
+    srand(time(NULL));
+
     test_derivation();
     test_derivation_fails_if_output_buffer_too_small();
 


### PR DESCRIPTION
(as explained [here](https://github.com/bitcoin-core/secp256k1/blob/89096c234dceecdc89953555b875d42579f4fd1d/examples/ecdsa.c#L46))

- Used throughout SGX HAL's implementation
- Fixed failing unit tests