### PR TITLE
Fixed SGX evidence claim deallocation to prevent potential memory leaks

### DIFF
--- a/firmware/src/hal/sgx/src/trusted/evidence.c
+++ b/firmware/src/hal/sgx/src/trusted/evidence.c
@@ -316,6 +316,14 @@ evidence_verify_and_extract_claims_fail:
     return false;
 }
 
+bool evidence_free_claims(oe_claim_t* claims, size_t claims_length) {
+    if (claims) {
+        if (oe_free_claims(claims, claims_length) != OE_OK)
+            return false;
+    }
+    return true;
+}
+
 oe_claim_t* evidence_get_claim(oe_claim_t* claims,
                                size_t claims_size,
                                const char* claim_name) {

--- a/firmware/src/hal/sgx/src/trusted/evidence.h
+++ b/firmware/src/hal/sgx/src/trusted/evidence.h
@@ -114,6 +114,17 @@ bool evidence_verify_and_extract_claims(oe_uuid_t format_id,
                                         size_t* claims_length);
 
 /**
+ * @brief Given a set of claims returned by evidence_verify_and_extract_claims,
+ * free them.
+ *
+ * @param claims            claims buffer
+ * @param claims_length     number of claims
+ *
+ * @returns true iff claims were succesfully freed
+ */
+bool evidence_free_claims(oe_claim_t* claims, size_t claims_length);
+
+/**
  * @brief Given a set of claims, find the one with the given name
  *
  * @param claims        the claim list

--- a/firmware/src/sgx/src/trusted/upgrade.c
+++ b/firmware/src/sgx/src/trusted/upgrade.c
@@ -444,7 +444,10 @@ unsigned int upgrade_process_apdu(volatile unsigned int rx) {
                 sizeof(upgrade_ctx.expected_message_hash));
         upgrade_ctx.state = upgrade_state_await_spec_sigs;
         if (claims) {
-            oe_free(claims);
+            if (!evidence_free_claims(claims, claims_size)) {
+                LOG("Error freeing claims\n");
+                THROW(ERR_INTERNAL);
+            }
             claims = NULL;
             claims_size = 0;
             claim = NULL;
@@ -453,7 +456,10 @@ unsigned int upgrade_process_apdu(volatile unsigned int rx) {
         return TX_NO_DATA();
     upgrade_process_apdu_start_error:
         if (claims) {
-            oe_free(claims);
+            if (!evidence_free_claims(claims, claims_size)) {
+                LOG("Error freeing claims\n");
+                THROW(ERR_INTERNAL);
+            }
             claims = NULL;
             claims_size = 0;
             claim = NULL;
@@ -639,7 +645,10 @@ unsigned int upgrade_process_apdu(volatile unsigned int rx) {
         upgrade_ctx.state = upgrade_state_ready_for_xchg;
         SET_APDU_OP(0); // Done
         if (claims) {
-            oe_free(claims);
+            if (!evidence_free_claims(claims, claims_size)) {
+                LOG("Error freeing claims\n");
+                THROW(ERR_INTERNAL);
+            }
             claims = NULL;
             claims_size = 0;
             claim = NULL;
@@ -648,7 +657,10 @@ unsigned int upgrade_process_apdu(volatile unsigned int rx) {
         return TX_NO_DATA();
     upgrade_process_apdu_identify_peer_error:
         if (claims) {
-            oe_free(claims);
+            if (!evidence_free_claims(claims, claims_size)) {
+                LOG("Error freeing claims\n");
+                THROW(ERR_INTERNAL);
+            }
             claims = NULL;
             claims_size = 0;
             claim = NULL;

--- a/firmware/src/sgx/test/upgrade/test_upgrade.c
+++ b/firmware/src/sgx/test/upgrade/test_upgrade.c
@@ -342,6 +342,12 @@ bool evidence_verify_and_extract_claims(oe_uuid_t format_id,
     return true;
 }
 
+bool evidence_free_claims(oe_claim_t* claims, size_t claims_length) {
+    assert(claims);
+    assert(claims_length);
+    return true;
+}
+
 oe_claim_t* evidence_get_claim(oe_claim_t* claims,
                                size_t claims_size,
                                const char* claim_name) {


### PR DESCRIPTION
- Added new `evidence_free_claims` to evidence module
- Replaced `oe_free` with `evidence_free_claims` for claim freeing throughout the SGX implementation
- Added `evidence_free_claims` test cases
- Fixed failing unit tests