### PR TITLE
Fixed incorrect deallocation of format settings

### DIFF
--- a/firmware/src/hal/sgx/src/trusted/evidence.c
+++ b/firmware/src/hal/sgx/src/trusted/evidence.c
@@ -90,6 +90,13 @@ bool evidence_get_format_settings(evidence_format_t* format) {
     return true;
 }
 
+bool evidence_free_format_settings(uint8_t* settings) {
+    if (!settings)
+        return true;
+
+    return oe_verifier_free_format_settings(settings) == OE_OK;
+}
+
 bool evidence_supports_format(oe_uuid_t format_id) {
     evidence_format_t format = {
         .id = format_id,
@@ -102,7 +109,7 @@ bool evidence_supports_format(oe_uuid_t format_id) {
     // Make sure we can get format settings
     if (!evidence_get_format_settings(&format))
         return false;
-    oe_free(format.settings);
+    evidence_free_format_settings(format.settings);
 
     // Make sure we can select format for attestation
     result = oe_attester_select_format(&format.id, 1, &selected_format);
@@ -161,7 +168,7 @@ bool evidence_generate(evidence_format_t* format,
         result, "Evidence generation failed", goto generate_evidence_error);
 
     if (gathered_settings) {
-        oe_free(format->settings);
+        evidence_free_format_settings(format->settings);
         format->settings = NULL;
         format->settings_size = 0;
     }
@@ -177,7 +184,7 @@ generate_evidence_error:
         *evidence_buffer_size = 0;
     }
     if (gathered_settings && format->settings) {
-        oe_free(format->settings);
+        evidence_free_format_settings(format->settings);
         format->settings = NULL;
         format->settings_size = 0;
     }

--- a/firmware/src/hal/sgx/src/trusted/evidence.h
+++ b/firmware/src/hal/sgx/src/trusted/evidence.h
@@ -69,6 +69,16 @@ void evidence_finalise();
 bool evidence_get_format_settings(evidence_format_t* format);
 
 /**
+ * @brief Given format settings returned by evidence_get_format_settings,
+ * free them.
+ *
+ * @param settings  settings buffer
+ *
+ * @returns true iff settings were succesfully freed
+ */
+bool evidence_free_format_settings(uint8_t* settings);
+
+/**
  * Tells whether a given format is supported for
  * evidence generation and verification
  *

--- a/firmware/src/hal/sgx/test/mock/openenclave/common.h
+++ b/firmware/src/hal/sgx/test/mock/openenclave/common.h
@@ -276,6 +276,8 @@ oe_result_t oe_verifier_get_format_settings(const oe_uuid_t* format_id,
                                             uint8_t** settings,
                                             size_t* settings_size);
 
+oe_result_t oe_verifier_free_format_settings(uint8_t* settings);
+
 oe_result_t oe_verify_evidence(const oe_uuid_t* format_id,
                                const uint8_t* evidence_buffer,
                                size_t evidence_buffer_size,

--- a/firmware/src/sgx/src/trusted/upgrade.c
+++ b/firmware/src/sgx/src/trusted/upgrade.c
@@ -573,7 +573,10 @@ unsigned int upgrade_process_apdu(volatile unsigned int rx) {
                 reset_upgrade();
                 THROW(ERR_UPGRADE_INTERNAL);
             }
-            oe_free(format.settings);
+            if (!evidence_free_format_settings(format.settings)) {
+                LOG("Unable to free format settings\n");
+                THROW(ERR_INTERNAL);
+            }
             explicit_bzero(&format, sizeof(format));
             upgrade_ctx.trx_offset = 0;
         }

--- a/firmware/src/sgx/test/upgrade/test_upgrade.c
+++ b/firmware/src/sgx/test/upgrade/test_upgrade.c
@@ -348,6 +348,11 @@ bool evidence_free_claims(oe_claim_t* claims, size_t claims_length) {
     return true;
 }
 
+bool evidence_free_format_settings(uint8_t* settings) {
+    assert(settings);
+    return true;
+}
+
 oe_claim_t* evidence_get_claim(oe_claim_t* claims,
                                size_t claims_size,
                                const char* claim_name) {


### PR DESCRIPTION
Fixed incorrect deallocation of format settings throughout the SGX implementation

- Added new `evidence_free_format_settings` function
- Replaced `oe_free` with `evidence_free_format_settings` throughout when freeing format settings
- Added new test cases for `evidence_free_format_settings`
- Fixed failing unit tests