### PR TITLE
SGX attestation validation: validate CRLs

### DIFF
--- a/middleware/admin/attestation_utils.py
+++ b/middleware/admin/attestation_utils.py
@@ -125,7 +125,7 @@ def compute_pubkeys_output(pubkeys_map):
     return pubkeys_output
 
 
-def get_root_of_trust(path):
+def get_sgx_root_of_trust(path):
     # From file
     if Path(path).is_file():
         return HSMCertificateV2ElementX509.from_pemfile(
@@ -137,6 +137,7 @@ def get_root_of_trust(path):
     ra_res = requests.get(path)
     if ra_res.status_code != 200:
         raise RuntimeError(f"Error fetching root of trust from {path}")
+
     return HSMCertificateV2ElementX509.from_pem(
         ra_res.content.decode(),
         HSMCertificateV2.ROOT_ELEMENT,

--- a/middleware/admin/x509_utils.py
+++ b/middleware/admin/x509_utils.py
@@ -1,0 +1,69 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021 RSK Labs Ltd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import re
+import requests
+from cryptography import x509
+from urllib.parse import unquote as url_unquote
+
+
+def split_pem_certificates(pem_data):
+    pattern = r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----"
+    certs = re.findall(pattern, pem_data, flags=re.DOTALL)
+    return certs
+
+
+def get_intel_pcs_x509_crl(url):
+    ra_res = requests.get(url)
+    if ra_res.status_code != 200:
+        raise RuntimeError(f"Error fetching CRL from {url}")
+
+    try:
+        # Parse CRL
+        ctype = ra_res.headers["Content-Type"]
+        if ctype in ["application/x-pem-file"]:
+            crl = x509.load_pem_x509_crl(ra_res.content)
+        elif ctype in ["application/pkix-crl", "application/x-x509-ca-cert"]:
+            crl = x509.load_der_x509_crl(ra_res.content)
+        else:
+            raise RuntimeError(f"Unknown CRL encoding: {ctype}")
+
+        # Parse certification chain (if any)
+        issuer_chain = ra_res.headers.get("SGX-PCK-CRL-Issuer-Chain")
+        if issuer_chain is not None:
+            issuer_chain = split_pem_certificates(url_unquote(issuer_chain))
+            issuer_chain = list(map(
+                lambda pem: x509.load_pem_x509_certificate(pem.encode()), issuer_chain))
+
+        warning = ra_res.headers.get("warning")
+        if warning is not None:
+            warning = f"Getting {url}: {warning}"
+
+        response = {
+            "crl": crl,
+            "issuer_chain": issuer_chain,
+            "warning": warning,
+        }
+
+        return response
+    except Exception as e:
+        raise RuntimeError(f"While fetching CRL from {url}: {e}")

--- a/middleware/admin/x509_validator.py
+++ b/middleware/admin/x509_validator.py
@@ -1,0 +1,122 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021 RSK Labs Ltd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from cryptography import x509
+from cryptography.hazmat.primitives.asymmetric import ec
+
+
+class X509CertificateValidator:
+    def __init__(self, crl_getter):
+        self._crl_getter = crl_getter
+
+    def get_crl_info(self, subject):
+        crl_getter = self._crl_getter
+        crl_info = None
+
+        try:
+            crldps = subject.extensions.\
+                get_extension_for_class(x509.CRLDistributionPoints).value
+
+            if len(crldps) == 0:
+                raise RuntimeError("No CRL distribution points found in certificate")
+
+            for crldp in crldps:
+                url = crldp.full_name[0].value
+                try:
+                    crl_info = crl_getter(url)
+                    break
+                except RuntimeError:
+                    pass
+
+            if crl_info is None:
+                raise RuntimeError("None of the distribution points "
+                                   "provided a valid CRL")
+
+            return crl_info
+        except Exception as e:
+            raise RuntimeError(f"Unable to fetch CRL for X509 certificate: {e}")
+
+    def validate(self, subject, issuer, now, check_crl=True):
+        try:
+            if not isinstance(subject, x509.Certificate) or \
+               not isinstance(issuer, x509.Certificate):
+                raise RuntimeError("Both subject and issuer must be "
+                                   "instances of x509.Certificate")
+
+            warnings = []
+
+            # 1. Check validity period
+            if subject.not_valid_before_utc > now or subject.not_valid_after_utc < now:
+                raise RuntimeError(f"{subject.subject} not within validity period")
+
+            # 2. Verify directly issued by issuer and
+            # also manually verify the signature just to
+            # have a second opinion XD
+            try:
+                subject.verify_directly_issued_by(issuer)
+
+                issuer.public_key().verify(
+                    subject.signature,
+                    subject.tbs_certificate_bytes,
+                    ec.ECDSA(subject.signature_hash_algorithm)
+                )
+            except Exception as e:
+                raise RuntimeError(f"Verifying {subject.subject} issued "
+                                   f"by {issuer.subject}: {e}")
+
+            # 3. Gather CRL and check validity
+            # (can be skipped for e.g. root of trust)
+            if check_crl:
+                crl_info = self.get_crl_info(subject)
+                crl = crl_info["crl"]
+
+                if not crl.is_signature_valid(issuer.public_key()):
+                    raise RuntimeError("Invalid CRL signature from "
+                                       f"{issuer.subject}")
+
+                revoked = crl.get_revoked_certificate_by_serial_number(
+                    subject.serial_number)
+                if revoked is not None:
+                    raise RuntimeError(f"{subject.subject} found in {issuer.subject} CRL")
+
+                # If the CRL issuer chain is present, check that the first
+                # element (the leaf) matches the given issuer
+                issuer_chain = crl_info["issuer_chain"]
+                if issuer_chain is not None:
+                    leaf = issuer_chain[0]
+                    if leaf != issuer:
+                        raise RuntimeError(f"CRL issuer chain leaf {leaf.subject} does "
+                                           f"not match certificate {subject.subject} "
+                                           f"issuer {issuer.subject}")
+
+                if crl_info["warning"] is not None:
+                    warnings.append(crl_info["warning"])
+
+            return {
+                "valid": True,
+                "warnings": warnings,
+            }
+        except Exception as e:
+            return {
+                "valid": False,
+                "reason": str(e),
+            }

--- a/middleware/tests/admin/test_attestation_utils.py
+++ b/middleware/tests/admin/test_attestation_utils.py
@@ -27,7 +27,7 @@ from unittest.mock import patch, mock_open
 from parameterized import parameterized
 from admin.attestation_utils import AdminError, PowHsmAttestationMessage, load_pubkeys, \
                                     compute_pubkeys_hash, compute_pubkeys_output, \
-                                    get_root_of_trust
+                                    get_sgx_root_of_trust
 from .test_attestation_utils_resources import TEST_PUBKEYS_JSON, \
                                               TEST_PUBKEYS_JSON_INVALID
 import logging
@@ -212,7 +212,7 @@ class TestGetRootOfTrust(TestCase):
         path.return_value.is_file.return_value = True
         HSMCertificateV2ElementX509.from_pemfile.return_value = "the-result"
 
-        self.assertEqual("the-result", get_root_of_trust("a-file-path"))
+        self.assertEqual("the-result", get_sgx_root_of_trust("a-file-path"))
 
         path.assert_called_with("a-file-path")
         HSMCertificateV2ElementX509.from_pemfile.assert_called_with(
@@ -226,7 +226,7 @@ class TestGetRootOfTrust(TestCase):
         HSMCertificateV2ElementX509.from_pemfile.side_effect = err
 
         with self.assertRaises(ValueError) as e:
-            get_root_of_trust("a-file-path")
+            get_sgx_root_of_trust("a-file-path")
         self.assertEqual(err, e.exception)
 
         path.assert_called_with("a-file-path")
@@ -244,7 +244,7 @@ class TestGetRootOfTrust(TestCase):
         })
         HSMCertificateV2ElementX509.from_pem.return_value = "the-result"
 
-        self.assertEqual("the-result", get_root_of_trust("a-url"))
+        self.assertEqual("the-result", get_sgx_root_of_trust("a-url"))
 
         path.assert_called_with("a-url")
         requests.get.assert_called_with("a-url")
@@ -261,7 +261,7 @@ class TestGetRootOfTrust(TestCase):
         })
 
         with self.assertRaises(RuntimeError) as e:
-            get_root_of_trust("a-url")
+            get_sgx_root_of_trust("a-url")
         self.assertIn("fetching root of trust", str(e.exception))
 
         path.assert_called_with("a-url")

--- a/middleware/tests/admin/test_x509_utils.py
+++ b/middleware/tests/admin/test_x509_utils.py
@@ -1,0 +1,237 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021 RSK Labs Ltd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from unittest import TestCase
+from unittest.mock import patch, Mock
+from parameterized import parameterized
+from admin.x509_utils import split_pem_certificates, get_intel_pcs_x509_crl
+import logging
+
+logging.disable(logging.CRITICAL)
+
+
+class TestSplitPemCertificates(TestCase):
+    def test_splits_ok(self):
+        test_certs = """
+-----BEGIN CERTIFICATE-----
+something
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----somethingelse-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----whatis
+thisstuff
+-----END CERTIFICATE-----
+"""
+        certs = split_pem_certificates(test_certs)
+        self.assertEqual(3, len(certs))
+        self.assertEqual(
+            "-----BEGIN CERTIFICATE-----something-----END CERTIFICATE-----",
+            certs[0].strip().replace("\n", ""))
+        self.assertEqual(
+            "-----BEGIN CERTIFICATE-----somethingelse-----END CERTIFICATE-----",
+            certs[1].strip().replace("\n", ""))
+        self.assertEqual(
+            "-----BEGIN CERTIFICATE-----whatisthisstuff-----END CERTIFICATE-----",
+            certs[2].strip().replace("\n", ""))
+
+    def test_nocerts(self):
+        self.assertEqual([], split_pem_certificates("not a certificate in sight"))
+
+    def test_certs_pref_suf(self):
+        self.assertEqual(
+            ["-----BEGIN CERTIFICATE-----"
+             "something-----END CERTIFICATE-----"],
+            split_pem_certificates(
+                "prefix\n\n\n-----BEGIN CERTIFICATE-----"
+                "something-----END CERTIFICATE-----\n\nsuffix\n\r\tmorestuff"
+            ))
+
+
+@patch("admin.x509_utils.url_unquote")
+@patch("admin.x509_utils.split_pem_certificates")
+@patch("admin.x509_utils.x509.load_der_x509_crl")
+@patch("admin.x509_utils.x509.load_pem_x509_crl")
+@patch("admin.x509_utils.requests")
+class TestGetIntelPcsX509CRL(TestCase):
+    def test_ok_pem(self, requests, load_pem, load_der, split, unquote):
+        res = Mock()
+        requests.get.return_value = res
+
+        res.status_code = 200
+        res.content = "the-crl-content"
+        res.headers = {
+            "Content-Type": "application/x-pem-file"
+        }
+        load_pem.return_value = "the-parsed-certificate"
+
+        self.assertEqual({
+            "crl": "the-parsed-certificate",
+            "issuer_chain": None,
+            "warning": None,
+        }, get_intel_pcs_x509_crl("the-crl-url"))
+
+        load_pem.assert_called_with("the-crl-content")
+        load_der.assert_not_called()
+        split.assert_not_called()
+        unquote.assert_not_called()
+
+    @parameterized.expand([
+        ("header 1", "application/pkix-crl"),
+        ("header 2", "application/x-x509-ca-cert"),
+    ])
+    def test_ok_der(self, requests, load_pem, load_der, split, unquote, _, ctype):
+        res = Mock()
+        requests.get.return_value = res
+
+        res.status_code = 200
+        res.content = "the-crl-content"
+        res.headers = {
+            "Content-Type": ctype,
+        }
+        load_der.return_value = "the-parsed-certificate"
+
+        self.assertEqual({
+            "crl": "the-parsed-certificate",
+            "issuer_chain": None,
+            "warning": None,
+        }, get_intel_pcs_x509_crl("the-crl-url"))
+
+        load_der.assert_called_with("the-crl-content")
+        load_pem.assert_not_called()
+        split.assert_not_called()
+        unquote.assert_not_called()
+
+    def test_ok_warning(self, requests, load_pem, load_der, split, unquote):
+        res = Mock()
+        requests.get.return_value = res
+
+        res.status_code = 200
+        res.content = "the-crl-content"
+        res.headers = {
+            "Content-Type": "application/x-pem-file",
+            "warning": "this-is-a-warning",
+        }
+        load_pem.return_value = "the-parsed-certificate"
+
+        self.assertEqual({
+            "crl": "the-parsed-certificate",
+            "issuer_chain": None,
+            "warning": "Getting the-crl-url: this-is-a-warning",
+        }, get_intel_pcs_x509_crl("the-crl-url"))
+
+        load_pem.assert_called_with("the-crl-content")
+        load_der.assert_not_called()
+        split.assert_not_called()
+        unquote.assert_not_called()
+
+    @patch("admin.x509_utils.x509.load_pem_x509_certificate")
+    def test_ok_issuer_chain(self, loadcer, requests, load_pem, load_der, split, unquote):
+        res = Mock()
+        requests.get.return_value = res
+
+        res.status_code = 200
+        res.content = "the-crl-content"
+        res.headers = {
+            "Content-Type": "application/x-x509-ca-cert",
+            "SGX-PCK-CRL-Issuer-Chain": "chain0-chain1-chain2",
+        }
+        load_der.return_value = "the-parsed-certificate"
+        loadcer.side_effect = lambda s: f"parsed-cert-{s.decode()}"
+        split.side_effect = lambda s: s.split(",")
+        unquote.side_effect = lambda s: s.replace("-", ",")
+
+        self.assertEqual({
+            "crl": "the-parsed-certificate",
+            "issuer_chain": [
+                "parsed-cert-chain0",
+                "parsed-cert-chain1",
+                "parsed-cert-chain2",
+            ],
+            "warning": None,
+        }, get_intel_pcs_x509_crl("the-crl-url"))
+
+        load_der.assert_called_with("the-crl-content")
+        load_pem.assert_not_called()
+        unquote.assert_called_with("chain0-chain1-chain2")
+        split.assert_called_with("chain0,chain1,chain2")
+        self.assertEqual(3, loadcer.call_count)
+
+    def test_error_response(self, requests, load_pem, load_der, split, unquote):
+        res = Mock()
+        requests.get.return_value = res
+
+        res.status_code = 404
+
+        with self.assertRaises(RuntimeError) as e:
+            get_intel_pcs_x509_crl("the-crl-url")
+        self.assertIn("Error fetching", str(e.exception))
+
+        load_pem.assert_not_called()
+        load_der.assert_not_called()
+        split.assert_not_called()
+        unquote.assert_not_called()
+
+    def test_error_unknown_ctype(self, requests, load_pem, load_der, split, unquote):
+        res = Mock()
+        requests.get.return_value = res
+
+        res.status_code = 200
+        res.headers = {
+            "Content-Type": "not-known"
+        }
+
+        with self.assertRaises(RuntimeError) as e:
+            get_intel_pcs_x509_crl("the-crl-url")
+        self.assertIn("While", str(e.exception))
+        self.assertIn("Unknown", str(e.exception))
+
+        load_pem.assert_not_called()
+        load_der.assert_not_called()
+        split.assert_not_called()
+        unquote.assert_not_called()
+
+    @parameterized.expand([
+        ("header 1", "application/x-pem-file", "pem"),
+        ("header 2", "application/pkix-crl", "der"),
+        ("header 3", "application/x-x509-ca-cert", "der"),
+    ])
+    def test_error_parsing(self, requests, load_pem, load_der,
+                           split, unquote, _, ctype, errct):
+        res = Mock()
+        requests.get.return_value = res
+
+        res.status_code = 200
+        res.content = "some-content"
+        res.headers = {
+            "Content-Type": ctype,
+        }
+
+        load_pem.side_effect = ValueError("pem parsing issue")
+        load_der.side_effect = ValueError("der parsing issue")
+
+        with self.assertRaises(RuntimeError) as e:
+            get_intel_pcs_x509_crl("the-crl-url")
+        self.assertIn("While", str(e.exception))
+        self.assertIn(f"{errct} parsing", str(e.exception))
+
+        split.assert_not_called()
+        unquote.assert_not_called()

--- a/middleware/tests/admin/test_x509_validator.py
+++ b/middleware/tests/admin/test_x509_validator.py
@@ -1,0 +1,369 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021 RSK Labs Ltd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from datetime import datetime, timedelta
+from unittest import TestCase
+from unittest.mock import patch, Mock, MagicMock
+from admin.x509_validator import X509CertificateValidator, x509
+import logging
+
+logging.disable(logging.CRITICAL)
+
+
+@patch("admin.x509_validator.ec")
+class TestX509CertificateValidatorValidate(TestCase):
+    def setUp(self):
+        self.crl_getter = Mock()
+        self.validator = X509CertificateValidator(self.crl_getter)
+
+        self.subject = MagicMock(spec=x509.Certificate)
+        self.subject.subject = "the subject"
+        self.issuer = MagicMock(spec=x509.Certificate)
+        self.issuer.subject = "the issuer"
+        self.issuer.public_key.return_value = Mock()
+
+        self.subject.not_valid_before_utc = datetime.now() - timedelta(days=100)
+        self.subject.not_valid_after_utc = datetime.now() + timedelta(days=100)
+        self.subject.signature_hash_algorithm = "the-algorithm"
+
+    def setup_mocks(self, ec):
+        ec.ECDSA.side_effect = lambda s: f"ecdsa-{s}"
+        self.validator.get_crl_info = Mock()
+
+    def mock_crl_info(self):
+        self.crl_info = {
+            "crl": Mock(),
+            "issuer_chain": None,
+            "warning": None,
+        }
+        self.validator.get_crl_info.return_value = self.crl_info
+
+        self.crl_info["crl"].is_signature_valid.return_value = True
+        self.crl_info["crl"].get_revoked_certificate_by_serial_number.return_value = None
+
+    def test_validate_ok(self, ec):
+        self.setup_mocks(ec)
+        self.mock_crl_info()
+
+        self.assertEqual({
+            "valid": True,
+            "warnings": [],
+        }, self.validator.validate(self.subject, self.issuer, datetime.now()))
+
+        self.subject.verify_directly_issued_by.assert_called_with(self.issuer)
+        self.issuer.public_key.return_value.verify.assert_called_with(
+            self.subject.signature,
+            self.subject.tbs_certificate_bytes,
+            "ecdsa-the-algorithm"
+        )
+        self.validator.get_crl_info.assert_called_with(self.subject)
+        self.crl_info["crl"].is_signature_valid.assert_called_with(
+            self.issuer.public_key())
+        self.crl_info["crl"].get_revoked_certificate_by_serial_number.\
+            assert_called_with(self.subject.serial_number)
+
+    def test_validate_ok_no_crl_checking(self, ec):
+        self.setup_mocks(ec)
+        self.validator.get_crl_info = Mock()
+
+        self.assertEqual({
+            "valid": True,
+            "warnings": [],
+        }, self.validator.validate(self.subject, self.issuer,
+                                   datetime.now(), check_crl=False))
+
+        self.subject.verify_directly_issued_by.assert_called_with(self.issuer)
+        self.issuer.public_key.return_value.verify.assert_called_with(
+            self.subject.signature,
+            self.subject.tbs_certificate_bytes,
+            "ecdsa-the-algorithm"
+        )
+        self.validator.get_crl_info.assert_not_called()
+
+    def test_validate_ok_with_crl_warnings(self, ec):
+        self.setup_mocks(ec)
+        self.mock_crl_info()
+        self.crl_info["warning"] = "this is a CRL warning"
+
+        self.assertEqual({
+            "valid": True,
+            "warnings": ["this is a CRL warning"],
+        }, self.validator.validate(self.subject, self.issuer, datetime.now()))
+
+    def test_validate_invalid_certificates(self, ec):
+        self.setup_mocks(ec)
+        self.mock_crl_info()
+
+        self.assertEqual({
+            "valid": False,
+            "reason": "Both subject and issuer must be instances of x509.Certificate",
+        }, self.validator.validate("not a certificate", self.issuer, datetime.now()))
+
+        self.assertEqual({
+            "valid": False,
+            "reason": "Both subject and issuer must be instances of x509.Certificate",
+        }, self.validator.validate(self.subject, "not a certificate", datetime.now()))
+
+        self.subject.verify_directly_issued_by.assert_not_called()
+        self.issuer.public_key.return_value.verify.assert_not_called()
+        self.validator.get_crl_info.assert_not_called()
+
+    def test_validate_invalid_period(self, ec):
+        self.setup_mocks(ec)
+        self.mock_crl_info()
+
+        self.assertEqual({
+            "valid": False,
+            "reason": "the subject not within validity period",
+        }, self.validator.validate(self.subject, self.issuer,
+                                   datetime.now() - timedelta(days=101)))
+
+        self.assertEqual({
+            "valid": False,
+            "reason": "the subject not within validity period",
+        }, self.validator.validate(self.subject, self.issuer,
+                                   datetime.now() + timedelta(days=101)))
+
+        self.subject.verify_directly_issued_by.assert_not_called()
+        self.issuer.public_key.return_value.verify.assert_not_called()
+        self.validator.get_crl_info.assert_not_called()
+
+    def test_validate_not_issued_by_issuer(self, ec):
+        self.setup_mocks(ec)
+        self.mock_crl_info()
+
+        self.subject.verify_directly_issued_by.side_effect = RuntimeError("oops")
+
+        self.assertEqual({
+            "valid": False,
+            "reason": "Verifying the subject issued by the issuer: oops",
+        }, self.validator.validate(self.subject, self.issuer, datetime.now()))
+
+        self.subject.verify_directly_issued_by.assert_called_with(self.issuer)
+        self.issuer.public_key.return_value.verify.assert_not_called()
+        self.validator.get_crl_info.assert_not_called()
+
+    def test_validate_signature_invalid(self, ec):
+        self.setup_mocks(ec)
+        self.mock_crl_info()
+
+        self.issuer.public_key.return_value.verify.side_effect = RuntimeError("oopsies")
+
+        self.assertEqual({
+            "valid": False,
+            "reason": "Verifying the subject issued by the issuer: oopsies",
+        }, self.validator.validate(self.subject, self.issuer, datetime.now()))
+
+        self.subject.verify_directly_issued_by.assert_called_with(self.issuer)
+        self.issuer.public_key.return_value.verify.assert_called_with(
+            self.subject.signature,
+            self.subject.tbs_certificate_bytes,
+            "ecdsa-the-algorithm"
+        )
+        self.validator.get_crl_info.assert_not_called()
+
+    def test_validate_crl_info_gathering_error(self, ec):
+        self.setup_mocks(ec)
+        self.mock_crl_info()
+        self.validator.get_crl_info.side_effect = RuntimeError("Error gathering CRL info")
+
+        self.assertEqual({
+            "valid": False,
+            "reason": "Error gathering CRL info",
+        }, self.validator.validate(self.subject, self.issuer, datetime.now()))
+
+        self.subject.verify_directly_issued_by.assert_called_with(self.issuer)
+        self.issuer.public_key.return_value.verify.assert_called_with(
+            self.subject.signature,
+            self.subject.tbs_certificate_bytes,
+            "ecdsa-the-algorithm"
+        )
+        self.validator.get_crl_info.assert_called_with(self.subject)
+        self.crl_info["crl"].is_signature_valid.assert_not_called()
+        self.crl_info["crl"].get_revoked_certificate_by_serial_number.assert_not_called()
+
+    def test_validate_crl_invalid_signature(self, ec):
+        self.setup_mocks(ec)
+        self.mock_crl_info()
+        self.crl_info["crl"].is_signature_valid.return_value = False
+
+        self.assertEqual({
+            "valid": False,
+            "reason": "Invalid CRL signature from the issuer",
+        }, self.validator.validate(self.subject, self.issuer, datetime.now()))
+
+        self.subject.verify_directly_issued_by.assert_called_with(self.issuer)
+        self.issuer.public_key.return_value.verify.assert_called_with(
+            self.subject.signature,
+            self.subject.tbs_certificate_bytes,
+            "ecdsa-the-algorithm"
+        )
+        self.validator.get_crl_info.assert_called_with(self.subject)
+        self.crl_info["crl"].is_signature_valid.assert_called_with(
+            self.issuer.public_key())
+        self.crl_info["crl"].get_revoked_certificate_by_serial_number.assert_not_called()
+
+    def test_validate_subject_revoked(self, ec):
+        self.setup_mocks(ec)
+        self.mock_crl_info()
+        self.crl_info["crl"].get_revoked_certificate_by_serial_number.return_value = 123
+
+        self.assertEqual({
+            "valid": False,
+            "reason": "the subject found in the issuer CRL",
+        }, self.validator.validate(self.subject, self.issuer, datetime.now()))
+
+        self.subject.verify_directly_issued_by.assert_called_with(self.issuer)
+        self.issuer.public_key.return_value.verify.assert_called_with(
+            self.subject.signature,
+            self.subject.tbs_certificate_bytes,
+            "ecdsa-the-algorithm"
+        )
+        self.validator.get_crl_info.assert_called_with(self.subject)
+        self.crl_info["crl"].is_signature_valid.assert_called_with(
+            self.issuer.public_key())
+        self.crl_info["crl"].get_revoked_certificate_by_serial_number.\
+            assert_called_with(self.subject.serial_number)
+
+    def test_validate_ok_with_crl_issuer_chain(self, ec):
+        self.setup_mocks(ec)
+        self.mock_crl_info()
+        self.crl_info["issuer_chain"] = [self.issuer, "something", "else"]
+
+        self.assertEqual({
+            "valid": True,
+            "warnings": [],
+        }, self.validator.validate(self.subject, self.issuer, datetime.now()))
+
+        self.subject.verify_directly_issued_by.assert_called_with(self.issuer)
+        self.issuer.public_key.return_value.verify.assert_called_with(
+            self.subject.signature,
+            self.subject.tbs_certificate_bytes,
+            "ecdsa-the-algorithm"
+        )
+        self.validator.get_crl_info.assert_called_with(self.subject)
+        self.crl_info["crl"].is_signature_valid.assert_called_with(
+            self.issuer.public_key())
+        self.crl_info["crl"].get_revoked_certificate_by_serial_number.\
+            assert_called_with(self.subject.serial_number)
+
+    def test_validate_error_crl_issuer_chain_leaf_mismatch(self, ec):
+        self.setup_mocks(ec)
+        self.mock_crl_info()
+        leaf = Mock()
+        leaf.subject = "different subject"
+        self.crl_info["issuer_chain"] = [leaf, "something", "else"]
+
+        self.assertEqual({
+            "valid": False,
+            "reason": "CRL issuer chain leaf different subject does not match "
+                      "certificate the subject issuer the issuer",
+        }, self.validator.validate(self.subject, self.issuer, datetime.now()))
+
+        self.subject.verify_directly_issued_by.assert_called_with(self.issuer)
+        self.issuer.public_key.return_value.verify.assert_called_with(
+            self.subject.signature,
+            self.subject.tbs_certificate_bytes,
+            "ecdsa-the-algorithm"
+        )
+        self.validator.get_crl_info.assert_called_with(self.subject)
+        self.crl_info["crl"].is_signature_valid.assert_called_with(
+            self.issuer.public_key())
+        self.crl_info["crl"].get_revoked_certificate_by_serial_number.\
+            assert_called_with(self.subject.serial_number)
+
+
+class TestX509CertificateValidatorGetCRLInfo(TestCase):
+    def setUp(self):
+        self.crl_getter = Mock()
+        self.validator = X509CertificateValidator(self.crl_getter)
+
+        self.crldp_ext = Mock()
+
+        self.subject = Mock()
+        self.subject.extensions.get_extension_for_class.return_value = self.crldp_ext
+
+    def test_get_crl_info_ok_first_url(self):
+        crldp_1 = Mock(full_name=[Mock(value="url-1")])
+        self.crldp_ext.value = [crldp_1, "doesnt-matter", "neither"]
+
+        self.crl_getter.return_value = "crl-for-url-1"
+
+        self.assertEqual("crl-for-url-1", self.validator.get_crl_info(self.subject))
+
+        self.crl_getter.assert_called_once()
+        self.crl_getter.assert_called_with("url-1")
+
+    def test_get_crl_info_ok_third_url(self):
+        crldp_1 = Mock(full_name=[Mock(value="url-1")])
+        crldp_2 = Mock(full_name=[Mock(value="url-2")])
+        crldp_3 = Mock(full_name=[Mock(value="url-3")])
+        self.crldp_ext.value = [crldp_1, crldp_2, crldp_3]
+
+        def getter(url):
+            self.assertRegex(url, "^url-[123]$")
+            if url[-1] == "3":
+                return "crl-for-url-3"
+
+            raise RuntimeError("Unable to retrieve")
+
+        self.crl_getter.side_effect = getter
+
+        self.assertEqual("crl-for-url-3", self.validator.get_crl_info(self.subject))
+
+        self.assertEqual(3, self.crl_getter.call_count)
+
+    def test_get_crl_info_all_urls_error(self):
+        crldp_1 = Mock(full_name=[Mock(value="url-1")])
+        crldp_2 = Mock(full_name=[Mock(value="url-2")])
+        crldp_3 = Mock(full_name=[Mock(value="url-3")])
+        self.crldp_ext.value = [crldp_1, crldp_2, crldp_3]
+
+        self.crl_getter.side_effect = RuntimeError("Unable to retrieve")
+
+        with self.assertRaises(RuntimeError) as e:
+            self.validator.get_crl_info(self.subject)
+        self.assertIn("None of the distribution", str(e.exception))
+
+        self.assertEqual(3, self.crl_getter.call_count)
+
+    def test_get_crl_info_no_crldp(self):
+        self.crldp_ext.value = []
+
+        self.crl_getter.side_effect = RuntimeError("Unable to retrieve")
+
+        with self.assertRaises(RuntimeError) as e:
+            self.validator.get_crl_info(self.subject)
+        self.assertIn("No CRL distribution", str(e.exception))
+
+        self.crl_getter.assert_not_called()
+
+    def test_get_crl_info_no_crldp_ext(self):
+        self.subject.extensions.get_extension_for_class.side_effect = RuntimeError("oops")
+
+        with self.assertRaises(RuntimeError) as e:
+            self.validator.get_crl_info(self.subject)
+        self.assertIn("Unable to fetch", str(e.exception))
+        self.assertIn("oops", str(e.exception))
+
+        self.crl_getter.assert_not_called()


### PR DESCRIPTION
- Refactored X509 certificate validation process into `x509_validator` module
- `x509_validator.X509CertificateValidator` also gathers and validates CRLs for each applicable certificate
- Added `x509_utils` for assorted x509 certificate utility functions
- Using `x509_validator.X509CertificateValidator` library for `HSMCertificateV2ElementX509` element validation
- Added `x509_utils` and `x509_validator` unit tests
- Fixed failing unit tests