### PR TITLE
SGX attestation validation: QE identity verification

### DIFF
--- a/middleware/admin/certificate_v2.py
+++ b/middleware/admin/certificate_v2.py
@@ -215,6 +215,9 @@ class HSMCertificateV2ElementSGXAttestationKey(HSMCertificateV2Element):
             "signed_by": self.signed_by,
         }
 
+    def get_collateral(self):
+        return self.message
+
 
 class HSMCertificateV2ElementX509(HSMCertificateV2Element):
     HEADER_BEGIN = "-----BEGIN CERTIFICATE-----"

--- a/middleware/admin/sgx_utils.py
+++ b/middleware/admin/sgx_utils.py
@@ -113,72 +113,82 @@ def get_sgx_extensions(certificate):
         return None
 
 
+def _get_auth_json_info(url, chain_header, digest_key, root_of_trust):
+    info_res = requests.get(url)
+    if info_res.status_code != 200:
+        raise RuntimeError(f"Server replied with status {info_res.status_code}")
+
+    warnings = []
+
+    # Parse info
+    ctype = info_res.headers["Content-Type"]
+    if ctype != "application/json":
+        raise RuntimeError(f"Unknown content-type: {ctype}")
+    info = json.loads(info_res.text)
+
+    warning = info_res.headers.get("warning")
+    if warning is not None:
+        warning = f"Getting {url}: {warning}"
+        warnings.append(warning)
+
+    # Parse certification chain
+    issuer_chain = info_res.headers.get(chain_header)
+    if issuer_chain is None:
+        raise RuntimeError("No issuer certification chain in response")
+
+    issuer_chain = split_pem_certificates(url_unquote(issuer_chain))
+    issuer_chain = list(map(
+        lambda pem: x509.load_pem_x509_certificate(pem.encode()), issuer_chain))
+
+    if len(issuer_chain) < 2:
+        raise RuntimeError("Expected at least two certificates "
+                           "in the issuer chain")
+
+    # Check root of trust is same as expected
+    ic_root = issuer_chain[-1]
+    if root_of_trust != ic_root:
+        raise RuntimeError(f"Root of trust ({root_of_trust.subject}) does not "
+                           f"match root of TCB info issuer chain: {ic_root.subject}")
+
+    # Validate certification chain in root to leaf order
+    validator = X509CertificateValidator(get_intel_pcs_x509_crl)
+    now = datetime.now(UTC)
+    issuer = ic_root
+    for subject in reversed(issuer_chain[:-1]):
+        result = validator.validate(subject, issuer, now)
+        if not result["valid"]:
+            raise RuntimeError("Error validating TCB info issuer "
+                               f"chain: {result["reason"]}")
+        warnings += result["warnings"]
+        issuer = subject
+
+    # Validate info signature
+    issuer = issuer_chain[0]
+    digest = sha256(json.dumps(
+        info[digest_key], indent=None, separators=(",", ":")).encode()).digest()
+    pubkey = ecdsa.VerifyingKey.from_string(issuer.public_key().public_bytes(
+            Encoding.X962, PublicFormat.CompressedPoint), ecdsa.NIST256p)
+    pubkey.verify_digest(
+        bytes.fromhex(info["signature"]),
+        digest,
+        sigdecode=ecdsa.util.sigdecode_string
+    )
+
+    return {
+        "info": info,
+        "warnings": warnings,
+    }
+
+
 def get_tcb_info(url, fmspc_hex, root_of_trust, update="early"):
     try:
         final_url = f"{url}?fmspc={fmspc_hex}&update={update}"
-        tcb_res = requests.get(final_url)
-        if tcb_res.status_code != 200:
-            raise RuntimeError(f"Server replied with status {tcb_res.status_code}")
-
-        warnings = []
-
-        # Parse TCB info
-        ctype = tcb_res.headers["Content-Type"]
-        if ctype != "application/json":
-            raise RuntimeError(f"Unknown content-type: {ctype}")
-        tcb_info = json.loads(tcb_res.text)
-
-        warning = tcb_res.headers.get("warning")
-        if warning is not None:
-            warning = f"Getting {final_url}: {warning}"
-            warnings.append(warning)
-
-        # Parse certification chain
-        issuer_chain = tcb_res.headers.get("TCB-Info-Issuer-Chain")
-        if issuer_chain is None:
-            raise RuntimeError("No issuer certification chain in response")
-
-        issuer_chain = split_pem_certificates(url_unquote(issuer_chain))
-        issuer_chain = list(map(
-            lambda pem: x509.load_pem_x509_certificate(pem.encode()), issuer_chain))
-
-        if len(issuer_chain) < 2:
-            raise RuntimeError("Expected at least two certificates "
-                               "in the TCB info issuer chain")
-
-        # Check root of trust is same as expected
-        ic_root = issuer_chain[-1]
-        if root_of_trust != ic_root:
-            raise RuntimeError(f"Root of trust ({root_of_trust.subject}) does not "
-                               f"match root of TCB info issuer chain: {ic_root.subject}")
-
-        # Validate certification chain in root to leaf order
-        validator = X509CertificateValidator(get_intel_pcs_x509_crl)
-        now = datetime.now(UTC)
-        issuer = ic_root
-        for subject in reversed(issuer_chain[:-1]):
-            result = validator.validate(subject, issuer, now)
-            if not result["valid"]:
-                raise RuntimeError("Error validating TCB info issuer "
-                                   f"chain: {result["reason"]}")
-            warnings += result["warnings"]
-            issuer = subject
-
-        # Validate TCB info signature
-        issuer = issuer_chain[0]
-        digest = sha256(json.dumps(
-            tcb_info["tcbInfo"], indent=None, separators=(",", ":")).encode()).digest()
-        pubkey = ecdsa.VerifyingKey.from_string(issuer.public_key().public_bytes(
-                Encoding.X962, PublicFormat.CompressedPoint), ecdsa.NIST256p)
-        pubkey.verify_digest(
-            bytes.fromhex(tcb_info["signature"]),
-            digest,
-            sigdecode=ecdsa.util.sigdecode_string
-        )
+        result = _get_auth_json_info(
+            final_url, "TCB-Info-Issuer-Chain", "tcbInfo", root_of_trust)
 
         return {
-            "tcb_info": tcb_info,
-            "warnings": warnings,
+            "tcb_info": result["info"],
+            "warnings": result["warnings"],
         }
     except Exception as e:
         raise RuntimeError(f"While fetching TCB info from {final_url}: {e}")
@@ -227,4 +237,77 @@ def validate_tcb_info(pck_info, tcb_info):
         return {
             "valid": False,
             "reason": f"While validating TCB information: {e}",
+        }
+
+
+def get_qeid_info(url, root_of_trust, update="early"):
+    try:
+        final_url = f"{url}?update={update}"
+        result = _get_auth_json_info(
+            final_url, "SGX-Enclave-Identity-Issuer-Chain",
+            "enclaveIdentity", root_of_trust)
+
+        return {
+            "qeid_info": result["info"],
+            "warnings": result["warnings"],
+        }
+    except Exception as e:
+        raise RuntimeError(f"While fetching QE identity info from {final_url}: {e}")
+
+
+def validate_qeid_info(report_info, qeid_info):
+    def fail(message):
+        return {
+            "valid": False,
+            "reason": message
+        }
+
+    try:
+        if report_info.mrsigner != bytes.fromhex(qeid_info["mrsigner"]):
+            return fail("QE MRSIGNER does not match the Intel QE identity information")
+
+        if report_info.isvprodid != qeid_info["isvprodid"]:
+            return fail("QE ISVPRODID does not match the Intel QE identity information")
+
+        masked_miscselect = report_info.miscselect & \
+            int.from_bytes(bytes.fromhex(qeid_info["miscselectMask"]),
+                           byteorder="little", signed=False)
+        miscselect = int.from_bytes(
+            bytes.fromhex(qeid_info["miscselect"]), byteorder="little", signed=False)
+        if masked_miscselect != miscselect:
+            return fail("QE MISCSELECT does not match the Intel QE identity information")
+
+        report_attributes = int.from_bytes(
+            report_info.attributes.flags.to_bytes(8, byteorder="little") +
+            report_info.attributes.xfrm.to_bytes(8, byteorder="little"),
+            byteorder="little", signed=False)
+        masked_attributes = report_attributes & \
+            int.from_bytes(bytes.fromhex(qeid_info["attributesMask"]),
+                           byteorder="little", signed=False)
+        attributes = int.from_bytes(
+            bytes.fromhex(qeid_info["attributes"]), byteorder="little", signed=False)
+        if masked_attributes != attributes:
+            return fail("QE ATTRIBUTES does not match the Intel QE identity information")
+
+        matching_level = None
+        for level in qeid_info["tcbLevels"]:
+            if report_info.isvsvn >= level["tcb"]["isvsvn"]:
+                matching_level = level
+                break
+
+        if matching_level is None:
+            return fail("QE TCB level is not supported")
+
+        return {
+            "valid": True,
+            "status": matching_level["tcbStatus"],
+            "date": matching_level["tcbDate"],
+            "advisories": matching_level.get("advisoryIDs", []),
+            "isvsvn": f"{report_info.isvsvn} >= {matching_level["tcb"]["isvsvn"]}",
+            "edn": qeid_info["tcbEvaluationDataNumber"],
+        }
+    except Exception as e:
+        return {
+            "valid": False,
+            "reason": f"While validating QE identity information: {e}",
         }

--- a/middleware/tests/admin/test_certificate_v2_element_sgx_attestation_key.py
+++ b/middleware/tests/admin/test_certificate_v2_element_sgx_attestation_key.py
@@ -25,6 +25,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 from admin.certificate_v2 import HSMCertificateV2Element, \
                                  HSMCertificateV2ElementSGXAttestationKey
+from sgx.envelope import SgxReportBody
 from .test_certificate_v2_resources import TEST_CERTIFICATE
 
 
@@ -167,5 +168,8 @@ class TestHSMCertificateV2ElementSGXAttestationKey(TestCase):
             })
         self.assertFalse(self.elem.is_valid(self.valid_certifier))
 
-    def test_get_collateral_none(self):
-        self.assertIsNone(self.elem.get_collateral())
+    def test_get_collateral_message(self):
+        self.assertEqual(SgxReportBody, type(self.elem.get_collateral()))
+        self.assertEqual(
+            self.elem.message.get_raw_data(),
+            self.elem.get_collateral().get_raw_data())


### PR DESCRIPTION
- Added collateral getter for `HSMCertificateV2ElementSGXAttestationKey`
- Factored out TCB information fetcher in `sgx_utils` library
- Added QE ID fetcher and validator helpers to `sgx_utils` library
- Added QE ID gathering, validation and output to sgx attestation verification tool
- Added QE ID related test cases to `verify_sgx_attestation`
- Added `sgx_utils` new helpers unit tests
- Fixed failing unit tests