### PR TITLE
Fixes all the findings from the static analyzer

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -21,7 +21,6 @@ jobs:
 
       - name: Run static analysis
         id: static-analysis
-        continue-on-error: true
         run: |
           firmware/static-analysis/gen-static-analysis
       

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,8 +1,6 @@
 name: "Static analysis"
 
-on:
-  push:
-    branches: [ "master" ]
+on: [push]
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/firmware/src/common/src/bigdigits.c
+++ b/firmware/src/common/src/bigdigits.c
@@ -46,6 +46,9 @@
 /* No asserts in stripped down version of this library */
 #define assert(x)
 
+// Disable static analyzer for this third-party library file
+#ifndef __clang_analyzer__
+
 #include "bigdigits.h"
 
 #define BITS_PER_HALF_DIGIT (BITS_PER_DIGIT / 2)
@@ -763,6 +766,8 @@ DIGIT_T spDivide(DIGIT_T *q, DIGIT_T *r, const DIGIT_T u[2], DIGIT_T v)
     *r = uu[0];
     return q2;
 }
+
+#endif // __clang_analyzer__
 
 // Platform-dependent code
 #ifndef HSM_PLATFORM_LEDGER

--- a/firmware/src/powhsm/src/hsm.c
+++ b/firmware/src/powhsm/src/hsm.c
@@ -317,16 +317,17 @@ void hsm_init() {
 
 unsigned int hsm_process_apdu(unsigned int rx) {
     unsigned int tx = 0;
+    unsigned short ex = APDU_OK;
 
     BEGIN_TRY {
         TRY {
             tx = hsm_process_command(rx);
-            THROW(0x9000);
         }
         CATCH_OTHER(e) {
-            tx = hsm_process_exception(e, tx);
+            ex = e;
         }
         FINALLY {
+            tx = hsm_process_exception(ex, tx);
         }
     }
     END_TRY;


### PR DESCRIPTION
- Fix finding on `svarint.c`
- Silence warnings for third-party library `bigdigits.c`
- Silence "dead assignment" warning on `hsm_process_apdu`
- Allow CI job to report the failure when the static analysis script fails

Detailed descriptions of each change in the commit messages.