### PR TITLE
Docs: added missing <signers_file> parameter to SGX build instructions

### DIFF
--- a/firmware/build/README.md
+++ b/firmware/build/README.md
@@ -13,7 +13,7 @@ To build the UI, just issue:
 ~/repo> firmware/build/build-ledger-ui <signer_hash> <signer_iteration> <signers_file>
 ```
 
-where `<signer_hash>` is the hash of the authorized signer version (only this signer can be opened in the UI once running), `<signer_iteration>` is the iteration of the authorized signer version (used for downgrade prevention) and `<signers_file>` is the basename of the signer authorizers header file (the file to be included for the build process should be at `~/firmware/src/ledger/ui/src/signer_authorization_signers/<signers_file>.h`).
+where `<signer_hash>` is the hash of the authorized signer version (only this signer can be opened in the UI once running), `<signer_iteration>` is the iteration of the authorized signer version (used for downgrade prevention) and `<signers_file>` is the basename of the signer authorizers header file (the file to be included for the build process should be at `~/firmware/src/common/src/upgrade_signers/<signers_file>.h`).
 
 There is also a *debug* version of the UI, which disables disallowing PINs with no alpha characters, therefore allowing for testing UI (and Signer) builds granting access to recovery mode without the need for wiping the device each time. This debug version is intended for development purposes only, and to build it, just issue:
 
@@ -59,10 +59,10 @@ Other alternative ways of generating this private key are completely valid, and 
 Once the private key already exists in the required disk location, the binaries are ready to be built. To build host and enclave (both are built simultaneously), just issue:
 
 ```bash
-~/repo> firmware/build/build-sgx <checkpoint> <minimum_difficulty> <network>
+~/repo> firmware/build/build-sgx <checkpoint> <minimum_difficulty> <network> <signers_file>
 ```
 
-where `<checkpoint>` is the desired blockchain checkpoint hash, `<minimum_difficulty>` is the minimum required difficulty (can be specified as a decimal number or as a hexadecimal - prefixed with `0x`), and `<network>` is the desired network the build is to target (one of `mainnet`, `testnet` or `regtest`).
+where `<checkpoint>` is the desired blockchain checkpoint hash, `<minimum_difficulty>` is the minimum required difficulty (can be specified as a decimal number or as a hexadecimal - prefixed with `0x`), `<network>` is the desired network the build is to target (one of `mainnet`, `testnet` or `regtest`) and `<signers_file>` is the basename of the signer authorizers header file (the file to be included for the build process should be at `~/firmware/src/common/src/upgrade_signers/<signers_file>.h`).
 
 For example, to build host and enclave with checkpoint `0x00f06dcff26ec8b4d373fbd53ee770e9348d9bd6a247ad4c86e82ceb3c2130ac`, minimum cumulative difficulty of `0x7c50933098` and the `testnet` network, issue:
 


### PR DESCRIPTION
Docs: added missing <signers_file> parameter to SGX build instructions, updated signers path.