### PR TITLE
Fixed integer underflow bug in trie parser

### DIFF
--- a/firmware/src/powhsm/src/trie.c
+++ b/firmware/src/powhsm/src/trie.c
@@ -160,6 +160,10 @@ uint8_t trie_consume(uint8_t *buf, const uint8_t len) {
             switch (svarint_result()) {
             case SVARINT_ST_DONE:
                 ctx->length = ctx->varint.value;
+                if (ctx->length == 0) {
+                    ctx->state = TRIE_ERR_INVALID;
+                    return i + 1;
+                }
                 ctx->callback(TRIE_EV_SHARED_PREFIX_LENGTH);
                 SHARED_PREFIX_TO_BYTES();
                 ctx->state = TRIE_ST_SHARED_PREFIX;

--- a/firmware/src/powhsm/test/trie/test_trie.c
+++ b/firmware/src/powhsm/test/trie/test_trie.c
@@ -611,6 +611,7 @@ int main() {
                "ccccccc22ff0000000001");
     test_error("4411ccccccccccccccccccccccccccccccccccccccccccccccccccccc"
                "ccccccc22ff0000000001");
+    test_error("50ff0012aabbccddeeff1122334455");
 
     return 0;
 }


### PR DESCRIPTION
- Disallowed trie nodes that signal a shared prefix with a varint length and specify length zero
- Added unit test case