### PR TITLE
Additional Ledger attestation validations

### DIFF
--- a/middleware/admin/certificate_v1.py
+++ b/middleware/admin/certificate_v1.py
@@ -41,6 +41,9 @@ class HSMCertificateRoot:
     def get_pubkey(self):
         return self.pubkey
 
+    def get_serialised_pubkey(self, compressed):
+        return self.get_pubkey().serialize(compressed=compressed).hex()
+
 
 class HSMCertificateElement:
     VALID_NAMES = ["device", "attestation", "ui", "signer"]
@@ -139,6 +142,9 @@ class HSMCertificateElement:
     def get_pubkey(self):
         return ec.PublicKey(bytes.fromhex(self.get_value()), raw=True)
 
+    def get_serialised_pubkey(self, compressed):
+        return self.get_pubkey().serialize(compressed=compressed).hex()
+
     def get_tweak(self):
         return self.tweak
 
@@ -216,6 +222,8 @@ class HSMCertificate:
                         "valid": True,
                         "value": current.get_value(),
                         "tweak": current.get_tweak(),
+                        "signed_by_pubkey":
+                            current_certifier.get_serialised_pubkey(compressed=False),
                         "collateral": collateral,
                     }
                     break

--- a/middleware/admin/certificate_v2.py
+++ b/middleware/admin/certificate_v2.py
@@ -71,6 +71,10 @@ class HSMCertificateV2Element:
     def get_pubkey(self):
         raise NotImplementedError(f"{type(self).__name__} can't provide a public key")
 
+    def get_serialised_pubkey(self, compressed):
+        return self.get_pubkey().to_string(
+            "compressed" if compressed else "uncompressed").hex()
+
     def is_valid(self, certifier):
         raise NotImplementedError(f"{type(self).__name__} can't be queried for validity")
 

--- a/middleware/admin/verify_ledger_attestation.py
+++ b/middleware/admin/verify_ledger_attestation.py
@@ -147,6 +147,14 @@ def do_verify_attestation(options):
             f"Invalid Signer attestation: error "
             f"validating '{signer_result["failed_element"]}'")
 
+    # Validate that the signer attestation is signed by the same public key
+    # as the UI attestation
+    if ui_result["signed_by_pubkey"] != signer_result["signed_by_pubkey"]:
+        raise AdminError(
+            "Signer attestation is not signed by the same public key "
+            f"as the UI attestation ({signer_result['signed_by_pubkey']} vs. "
+            f"{ui_result['signed_by_pubkey']})")
+
     signer_message = bytes.fromhex(signer_result["value"])
     signer_hash = bytes.fromhex(signer_result["tweak"])
     lmh_match = SIGNER_LEGACY_MESSAGE_HEADER_REGEX.match(signer_message)

--- a/middleware/admin/verify_ledger_attestation.py
+++ b/middleware/admin/verify_ledger_attestation.py
@@ -145,7 +145,7 @@ def do_verify_attestation(options):
     if not signer_result["valid"]:
         raise AdminError(
             f"Invalid Signer attestation: error "
-            f"validating '{signer_result["failed_element"]}'")
+            f"validating '{signer_result['failed_element']}'")
 
     # Validate that the signer attestation is signed by the same public key
     # as the UI attestation

--- a/middleware/tests/admin/test_certificate_v1.py
+++ b/middleware/tests/admin/test_certificate_v1.py
@@ -276,12 +276,14 @@ class TestHSMCertificate(TestCase):
                 "valid": True,
                 "value": att_pubkey,
                 "tweak": None,
+                "signed_by_pubkey": device_pubkey,
                 "collateral": {}
             },
             'device': {
                 "valid": True,
                 "value": device_pubkey,
                 "tweak": None,
+                "signed_by_pubkey": root_pubkey,
                 "collateral": {}
             },
         }, cert.validate_and_get_values(root_of_trust))
@@ -328,6 +330,7 @@ class TestHSMCertificate(TestCase):
                 "valid": True,
                 "value": device_pubkey,
                 "tweak": None,
+                "signed_by_pubkey": root_pubkey,
                 "collateral": {}
             },
         }, cert.validate_and_get_values(root_of_trust))

--- a/middleware/tests/admin/test_certificate_v2.py
+++ b/middleware/tests/admin/test_certificate_v2.py
@@ -23,8 +23,9 @@
 from unittest import TestCase
 from parameterized import parameterized
 from admin.certificate_v1 import HSMCertificate
-from admin.certificate_v2 import HSMCertificateV2
+from admin.certificate_v2 import HSMCertificateV2, HSMCertificateV2Element
 from .test_certificate_v2_resources import TEST_CERTIFICATE
+from types import SimpleNamespace
 
 
 class TestHSMCertificateV2(TestCase):
@@ -61,8 +62,24 @@ class TestHSMCertificateV2(TestCase):
             def get_collateral(self):
                 return self.collateral
 
+            def get_pubkey(self):
+                return mock_pubkey(self.name)
+
+            def get_serialised_pubkey(self, compressed):
+                return HSMCertificateV2Element.get_serialised_pubkey(self, compressed)
+
         def mock_element_factory(k, d):
             return MockElement(d)
+
+        def mock_pubkey(name):
+            class MockPubkey:
+                def __init__(self, name):
+                    self.name = name
+
+                def to_string(self, compressed):
+                    return SimpleNamespace(hex=lambda: f"pubkey-for-{self.name}")
+
+            return MockPubkey(name)
 
         HSMCertificateV2.ELEMENT_FACTORY = mock_element_factory
 
@@ -74,6 +91,7 @@ class TestHSMCertificateV2(TestCase):
                     "valid": True,
                     "value": "the value for quote",
                     "tweak": None,
+                    "signed_by_pubkey": "pubkey-for-attestation",
                     "collateral": {
                         "platform_ca": "collateral-for-platform_ca",
                         "quoting_enclave": "collateral-for-quoting_enclave",

--- a/middleware/tests/admin/test_verify_ledger_attestation.py
+++ b/middleware/tests/admin/test_verify_ledger_attestation.py
@@ -94,12 +94,14 @@ class TestVerifyLedgerAttestation(TestCase):
             "valid": True,
             "value": self.ui_msg.hex(),
             "tweak": self.ui_hash.hex(),
+            "signed_by_pubkey": "att_pubkey",
             "collateral": {},
         }
         self.result['signer'] = {
             "valid": True,
             "value": self.signer_msg.hex(),
             "tweak": self.signer_hash.hex(),
+            "signed_by_pubkey": "att_pubkey",
             "collateral": {},
         }
 
@@ -117,6 +119,7 @@ class TestVerifyLedgerAttestation(TestCase):
             "valid": True,
             "value": self.signer_msg.hex(),
             "tweak": self.signer_hash.hex(),
+            "signed_by_pubkey": "att_pubkey",
             "collateral": {},
         }
 
@@ -208,6 +211,45 @@ class TestVerifyLedgerAttestation(TestCase):
             fill="-",
         )
         self.assertEqual(expected_call_signer, head_mock.call_args_list[2])
+
+    @patch("admin.verify_ledger_attestation.head")
+    @patch("admin.verify_ledger_attestation.HSMCertificate")
+    @patch("admin.verify_ledger_attestation.load_pubkeys")
+    def test_verify_attestation_ui_signer_different_certifiers(self,
+                                                               load_pubkeys_mock,
+                                                               certificate_mock,
+                                                               head_mock, _):
+        load_pubkeys_mock.return_value = self.public_keys
+        att_cert = Mock()
+        att_cert.validate_and_get_values = Mock(return_value=self.result)
+        certificate_mock.from_jsonfile = Mock(return_value=att_cert)
+
+        self.result["signer"]["signed_by_pubkey"] = "different_pubkey"
+
+        with self.assertRaises(AdminError) as e:
+            do_verify_attestation(self.default_options)
+
+        self.assertIn("is not signed by the same", str(e.exception))
+
+        load_pubkeys_mock.assert_called_with(self.pubkeys_path)
+        self.assertEqual([call(self.certification_path)],
+                         certificate_mock.from_jsonfile.call_args_list)
+
+        expected_call_ui = call(
+            [
+                "UI verified with:",
+                f"UD value: {'aa'*32}",
+                f"Derived public key ({EXPECTED_UI_DERIVATION_PATH}): "
+                f"{self.expected_ui_pubkey}",
+                f"Authorized signer hash: {'cc'*32}",
+                "Authorized signer iteration: 291",
+                f"Installed UI hash: {'ee'*32}",
+                "Installed UI version: 5.6",
+            ],
+            fill="-",
+        )
+        self.assertEqual(expected_call_ui, head_mock.call_args_list[1])
+        self.assertEqual(head_mock.call_count, 2)
 
     def test_verify_attestation_no_certificate(self, _):
         options = self.default_options
@@ -352,6 +394,7 @@ class TestVerifyLedgerAttestation(TestCase):
             "valid": True,
             "value": signer_header,
             "tweak": self.signer_hash.hex(),
+            "signed_by_pubkey": "att_pubkey",
             "collateral": {},
         }
         att_cert = Mock()
@@ -376,6 +419,7 @@ class TestVerifyLedgerAttestation(TestCase):
             "valid": True,
             "value": signer_header,
             "tweak": self.signer_hash.hex(),
+            "signed_by_pubkey": "att_pubkey",
             "collateral": {},
         }
         att_cert = Mock()


### PR DESCRIPTION
Ledger attestation verifier: check that UI and Signer are signed by the same public key:
- Adding signer public key to output for each target
- Adding serialised public key getter for certificate element classes
- Adding same-public-key validation for UI and Signer
- Added and updated unit tests