### PR TITLE
Additional SGX attestation validations

### DIFF
--- a/middleware/admin/sgx_utils.py
+++ b/middleware/admin/sgx_utils.py
@@ -225,13 +225,20 @@ def validate_tcb_info(pck_info, tcb_info):
                 "reason": "TCB level is unsupported"
             }
 
+        warnings = []
+        if matching_level["tcbStatus"] != "UpToDate":
+            warnings.append("Status is NOT UpToDate")
+        if len(matching_level.get("advisoryIDs", [])) > 0:
+            warnings.append("Advisories present")
+
         return {
             "valid": True,
             "status": matching_level["tcbStatus"],
             "date": matching_level["tcbDate"],
-            "advisories": matching_level["advisoryIDs"],
+            "advisories": matching_level.get("advisoryIDs", []),
             "svns": svns_info,
             "edn": tcb_info["tcbEvaluationDataNumber"],
+            "warnings": warnings,
         }
     except Exception as e:
         return {
@@ -298,6 +305,12 @@ def validate_qeid_info(report_info, qeid_info):
         if matching_level is None:
             return fail("QE TCB level is not supported")
 
+        warnings = []
+        if matching_level["tcbStatus"] != "UpToDate":
+            warnings.append("Status is NOT UpToDate")
+        if len(matching_level.get("advisoryIDs", [])) > 0:
+            warnings.append("Advisories present")
+
         return {
             "valid": True,
             "status": matching_level["tcbStatus"],
@@ -305,6 +318,7 @@ def validate_qeid_info(report_info, qeid_info):
             "advisories": matching_level.get("advisoryIDs", []),
             "isvsvn": f"{report_info.isvsvn} >= {matching_level["tcb"]["isvsvn"]}",
             "edn": qeid_info["tcbEvaluationDataNumber"],
+            "warnings": warnings,
         }
     except Exception as e:
         return {

--- a/middleware/admin/sgx_utils.py
+++ b/middleware/admin/sgx_utils.py
@@ -55,7 +55,7 @@ def _parse_asn1_extensions(extension, base_oid, spec):
         result = {}
         for index, item in enumerate(items):
             xt = value[index]
-            item_oid = f"{base_oid}{item["oid"]}"
+            item_oid = f"{base_oid}{item['oid']}"
             result[item["name"]] = _parse_asn1_extensions(xt, item_oid, item)
         return result
 
@@ -70,7 +70,7 @@ def _parse_asn1_extensions(extension, base_oid, spec):
         assert_type(base_oid, value, Integer)
         return int(value)
 
-    raise RuntimeError(f"Unknown spec type {spec["type"]}")
+    raise RuntimeError(f"Unknown spec type {spec['type']}")
 
 
 def get_sgx_extensions(certificate):
@@ -158,7 +158,7 @@ def _get_auth_json_info(url, chain_header, digest_key, root_of_trust):
         result = validator.validate(subject, issuer, now)
         if not result["valid"]:
             raise RuntimeError("Error validating TCB info issuer "
-                               f"chain: {result["reason"]}")
+                               f"chain: {result['reason']}")
         warnings += result["warnings"]
         issuer = subject
 
@@ -316,7 +316,7 @@ def validate_qeid_info(report_info, qeid_info):
             "status": matching_level["tcbStatus"],
             "date": matching_level["tcbDate"],
             "advisories": matching_level.get("advisoryIDs", []),
-            "isvsvn": f"{report_info.isvsvn} >= {matching_level["tcb"]["isvsvn"]}",
+            "isvsvn": f"{report_info.isvsvn} >= {matching_level['tcb']['isvsvn']}",
             "edn": qeid_info["tcbEvaluationDataNumber"],
             "warnings": warnings,
         }

--- a/middleware/admin/verify_sgx_attestation.py
+++ b/middleware/admin/verify_sgx_attestation.py
@@ -135,11 +135,7 @@ def do_verify_attestation(options):
         if not tcb_validation_result["valid"]:
             raise AdminError(f"TCB error: {tcb_validation_result["reason"]}")
 
-        if len(tcb_info_res["warnings"]) > 0:
-            info("***** TCB INFO WARNINGS *****")
-            for w in tcb_info_res["warnings"]:
-                info(w)
-            info("*****************************")
+        tcb_warnings = tcb_validation_result["warnings"] + tcb_info_res["warnings"]
     except Exception as e:
         raise AdminError(f"While trying to verify TCB information: {e}")
 
@@ -158,11 +154,7 @@ def do_verify_attestation(options):
         if not qeid_validation_result["valid"]:
             raise AdminError(f"QE ID error: {qeid_validation_result["reason"]}")
 
-        if len(qeid_info_res["warnings"]) > 0:
-            info("***** QE ID INFO WARNINGS *****")
-            for w in qeid_info_res["warnings"]:
-                info(w)
-            info("*****************************")
+        qeid_warnings = qeid_validation_result["warnings"] + qeid_info_res["warnings"]
     except Exception as e:
         raise AdminError(f"While trying to verify QE ID information: {e}")
 
@@ -201,7 +193,13 @@ def do_verify_attestation(options):
         f"Timestamp: {powhsm_message.timestamp}",
     ]
 
-    tcb_info = [
+    tcb_info = []
+    if len(tcb_warnings) > 0:
+        tcb_info.append("************* WARNINGS *************")
+        tcb_info += map(lambda w: f"> {w}", tcb_warnings)
+        tcb_info.append("************************************")
+
+    tcb_info += [
         f"Status: {tcb_validation_result["status"]}",
         f"Issued: {tcb_validation_result["date"]}",
         f"Advisories: {", ".join(tcb_validation_result["advisories"]) or "None"}",
@@ -211,7 +209,13 @@ def do_verify_attestation(options):
 
     tcb_info += map(lambda svn: f"  - {svn}", tcb_validation_result["svns"])
 
-    qeid_info = [
+    qeid_info = []
+    if len(qeid_warnings) > 0:
+        qeid_info.append("************* WARNINGS *************")
+        qeid_info += map(lambda w: f"> {w}", qeid_warnings)
+        qeid_info.append("************************************")
+
+    qeid_info += [
         f"Status: {qeid_validation_result["status"]}",
         f"Issued: {qeid_validation_result["date"]}",
         f"Advisories: {", ".join(qeid_validation_result["advisories"]) or "None"}",

--- a/middleware/admin/verify_sgx_attestation.py
+++ b/middleware/admin/verify_sgx_attestation.py
@@ -115,7 +115,7 @@ def do_verify_attestation(options):
     if not powhsm_result["valid"]:
         raise AdminError(
             f"Invalid powHSM attestation: error "
-            f"validating '{powhsm_result["failed_element"]}'")
+            f"validating '{powhsm_result['failed_element']}'")
     powhsm_collateral = powhsm_result["collateral"]
     powhsm_result = powhsm_result["value"]
 
@@ -133,7 +133,7 @@ def do_verify_attestation(options):
 
         tcb_validation_result = validate_tcb_info(pck_collateral, tcb_info)
         if not tcb_validation_result["valid"]:
-            raise AdminError(f"TCB error: {tcb_validation_result["reason"]}")
+            raise AdminError(f"TCB error: {tcb_validation_result['reason']}")
 
         tcb_warnings = tcb_validation_result["warnings"] + tcb_info_res["warnings"]
     except Exception as e:
@@ -152,7 +152,7 @@ def do_verify_attestation(options):
 
         qeid_validation_result = validate_qeid_info(qe_collateral, qeid_info)
         if not qeid_validation_result["valid"]:
-            raise AdminError(f"QE ID error: {qeid_validation_result["reason"]}")
+            raise AdminError(f"QE ID error: {qeid_validation_result['reason']}")
 
         qeid_warnings = qeid_validation_result["warnings"] + qeid_info_res["warnings"]
     except Exception as e:
@@ -200,10 +200,10 @@ def do_verify_attestation(options):
         tcb_info.append("************************************")
 
     tcb_info += [
-        f"Status: {tcb_validation_result["status"]}",
-        f"Issued: {tcb_validation_result["date"]}",
-        f"Advisories: {", ".join(tcb_validation_result["advisories"]) or "None"}",
-        f"TCB evaluation data number: {tcb_validation_result["edn"]}",
+        f"Status: {tcb_validation_result['status']}",
+        f"Issued: {tcb_validation_result['date']}",
+        f"Advisories: {', '.join(tcb_validation_result['advisories']) or 'None'}",
+        f"TCB evaluation data number: {tcb_validation_result['edn']}",
         "SVNs:"
     ]
 
@@ -216,11 +216,11 @@ def do_verify_attestation(options):
         qeid_info.append("************************************")
 
     qeid_info += [
-        f"Status: {qeid_validation_result["status"]}",
-        f"Issued: {qeid_validation_result["date"]}",
-        f"Advisories: {", ".join(qeid_validation_result["advisories"]) or "None"}",
-        f"TCB evaluation data number: {qeid_validation_result["edn"]}",
-        f"ISVSVN: {qeid_validation_result["isvsvn"]}",
+        f"Status: {qeid_validation_result['status']}",
+        f"Issued: {qeid_validation_result['date']}",
+        f"Advisories: {', '.join(qeid_validation_result['advisories']) or 'None'}",
+        f"TCB evaluation data number: {qeid_validation_result['edn']}",
+        f"ISVSVN: {qeid_validation_result['isvsvn']}",
     ]
 
     head(

--- a/middleware/tests/admin/test_sgx_utils.py
+++ b/middleware/tests/admin/test_sgx_utils.py
@@ -30,6 +30,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives.serialization import PublicFormat, Encoding
 from hashlib import sha256
 import ecdsa
+from copy import deepcopy
 from admin.sgx_utils import get_sgx_extensions, get_tcb_info, validate_tcb_info, \
                             get_qeid_info, validate_qeid_info, get_intel_pcs_x509_crl
 import logging
@@ -533,7 +534,70 @@ class TestSgxUtilsValidateTcbInfo(TestCase):
                 "PCESVN: 1717 >= 1716",
             ],
             "edn": 1234,
+            "warnings": ["Status is NOT UpToDate", "Advisories present"],
         }, validate_tcb_info(self.pck_info, self.tcb_info["tcbInfo"]))
+
+    def test_validate_tcb_info_ok_utd(self):
+        tcb_info = deepcopy(self.tcb_info["tcbInfo"])
+        tcb_info["tcbLevels"][1]["tcbStatus"] = "UpToDate"
+        self.assertEqual({
+            "valid": True,
+            "status": "UpToDate",
+            "date": "the-date-we-want",
+            "advisories": ["the-advisory-1", "the-advisory-2", "the-advisory-3"],
+            "svns": [
+                "Comp 01: 11 >= 10",
+                "Comp 02: 22 >= 21",
+                "Comp 03: 33 >= 32",
+                "Comp 04: 44 >= 43",
+                "Comp 05: 55 >= 54",
+                "Comp 06: 66 >= 65",
+                "Comp 07: 77 >= 76",
+                "Comp 08: 88 >= 87",
+                "Comp 09: 99 >= 98",
+                "Comp 10: 1010 >= 1009",
+                "Comp 11: 1111 >= 1110",
+                "Comp 12: 1212 >= 1211",
+                "Comp 13: 1313 >= 1312",
+                "Comp 14: 1414 >= 1413",
+                "Comp 15: 1515 >= 1514",
+                "Comp 16: 1616 >= 1615",
+                "PCESVN: 1717 >= 1716",
+            ],
+            "edn": 1234,
+            "warnings": ["Advisories present"],
+        }, validate_tcb_info(self.pck_info, tcb_info))
+
+    def test_validate_tcb_info_ok_no_adv(self):
+        tcb_info = deepcopy(self.tcb_info["tcbInfo"])
+        tcb_info["tcbLevels"][1].pop("advisoryIDs")
+        self.assertEqual({
+            "valid": True,
+            "status": "the-status-we-want",
+            "date": "the-date-we-want",
+            "advisories": [],
+            "svns": [
+                "Comp 01: 11 >= 10",
+                "Comp 02: 22 >= 21",
+                "Comp 03: 33 >= 32",
+                "Comp 04: 44 >= 43",
+                "Comp 05: 55 >= 54",
+                "Comp 06: 66 >= 65",
+                "Comp 07: 77 >= 76",
+                "Comp 08: 88 >= 87",
+                "Comp 09: 99 >= 98",
+                "Comp 10: 1010 >= 1009",
+                "Comp 11: 1111 >= 1110",
+                "Comp 12: 1212 >= 1211",
+                "Comp 13: 1313 >= 1312",
+                "Comp 14: 1414 >= 1413",
+                "Comp 15: 1515 >= 1514",
+                "Comp 16: 1616 >= 1615",
+                "PCESVN: 1717 >= 1716",
+            ],
+            "edn": 1234,
+            "warnings": ["Status is NOT UpToDate"],
+        }, validate_tcb_info(self.pck_info, tcb_info))
 
     def test_validate_tcb_info_notfound(self):
         self.tcb_info["tcbInfo"]["tcbLevels"] = self.tcb_info["tcbInfo"]["tcbLevels"][0:1]
@@ -837,7 +901,35 @@ class TestSgxUtilsValidateQeIdInfo(TestCase):
             "advisories": ["advisory-1", "advisory-2"],
             "edn": 456,
             "isvsvn": "123 >= 120",
+            "warnings": ["Status is NOT UpToDate", "Advisories present"],
         }, validate_qeid_info(self.qe_report_info, self.qeid_info))
+
+    def test_validate_qeid_info_ok_utd(self):
+        qeid_info = deepcopy(self.qeid_info)
+        qeid_info["tcbLevels"][2]["tcbStatus"] = "UpToDate"
+        self.assertEqual({
+            "valid": True,
+            "status": "UpToDate",
+            "date": "the tcb date",
+            "advisories": ["advisory-1", "advisory-2"],
+            "edn": 456,
+            "isvsvn": "123 >= 120",
+            "warnings": ["Advisories present"],
+        }, validate_qeid_info(self.qe_report_info, qeid_info))
+
+    def test_validate_qeid_info_ok_no_adv(self):
+        self.maxDiff = None
+        qeid_info = deepcopy(self.qeid_info)
+        qeid_info["tcbLevels"][2].pop("advisoryIDs")
+        self.assertEqual({
+            "valid": True,
+            "status": "the tcb status",
+            "date": "the tcb date",
+            "advisories": [],
+            "edn": 456,
+            "isvsvn": "123 >= 120",
+            "warnings": ["Status is NOT UpToDate"],
+        }, validate_qeid_info(self.qe_report_info, qeid_info))
 
     def test_validate_qeid_info_mrsigner(self):
         self.qe_report_info.mrsigner = "bb"*32

--- a/middleware/tests/admin/test_verify_sgx_attestation.py
+++ b/middleware/tests/admin/test_verify_sgx_attestation.py
@@ -136,6 +136,7 @@ class TestVerifySgxAttestation(TestCase):
             "advisories": ["adv-1", "adv-2"],
             "edn": 123,
             "svns": ["one: 34", "two: 17", "three: 87"],
+            "warnings": ["wv1", "wv2"],
         }
         self.get_qeid_info = get_qeid_info
         get_qeid_info.return_value = {
@@ -151,7 +152,8 @@ class TestVerifySgxAttestation(TestCase):
             "date": "another date",
             "advisories": ["adv-3", "adv-4"],
             "edn": 456,
-            "isvsvn": 789
+            "isvsvn": "678 >= 567",
+            "warnings": ["wv3", "wv4"],
         }
 
     @parameterized.expand([
@@ -227,6 +229,12 @@ class TestVerifySgxAttestation(TestCase):
         ], fill="-"))
         self.assertEqual(head.call_args_list[2], call([
             "TCB Information:",
+            "************* WARNINGS *************",
+            "> wv1",
+            "> wv2",
+            "> w1",
+            "> w2",
+            "************************************",
             "Status: the status",
             "Issued: a date",
             "Advisories: adv-1, adv-2",
@@ -235,6 +243,20 @@ class TestVerifySgxAttestation(TestCase):
             "  - one: 34",
             "  - two: 17",
             "  - three: 87",
+        ], fill="-"))
+        self.assertEqual(head.call_args_list[3], call([
+            "QE Identity Information:",
+            "************* WARNINGS *************",
+            "> wv3",
+            "> wv4",
+            "> w3",
+            "> w4",
+            "************************************",
+            "Status: another status",
+            "Issued: another date",
+            "Advisories: adv-3, adv-4",
+            "TCB evaluation data number: 456",
+            "ISVSVN: 678 >= 567",
         ], fill="-"))
 
     def test_verify_attestation_err_get_root(self, get_sgx_root_of_trust, load_pubkeys,


### PR DESCRIPTION
SGX attestation verifier: emitting warnings for non-up to date statuses and/or presence of advisories:
- Emission of warnings both for statuses and advisories in TCB and Quoting Enclave identity
- Added and updated unit tests