### PR TITLE
Changed secret store read return data type

### DIFF
--- a/firmware/src/hal/sgx/src/trusted/access.c
+++ b/firmware/src/hal/sgx/src/trusted/access.c
@@ -57,11 +57,14 @@ bool access_init(access_wiped_callback_t wiped_callback) {
     }
 
     // Read password
-    if (!(G_password_length = sest_read(
+    size_t password_read_length;
+    if (!(password_read_length = sest_read(
               SEST_PASSWORD_KEY, (uint8_t*)G_password, sizeof(G_password)))) {
         LOG("Could not load the current password\n");
         return false;
     }
+    // If password read succeeded, then password length fits in a single byte
+    G_password_length = (uint8_t)password_read_length;
 
     // Make sure password is sound
     if (!pin_policy_is_valid_pin(G_password, G_password_length)) {

--- a/firmware/src/hal/sgx/src/trusted/secret_store.c
+++ b/firmware/src/hal/sgx/src/trusted/secret_store.c
@@ -133,9 +133,9 @@ static bool is_header_valid(const char* key,
  *
  * @returns the length of the unsealed data, or SEST_ERROR upon error
  */
-static uint8_t unseal_data(const sealed_secret_t* sealed_secret,
-                           uint8_t* dest,
-                           size_t dest_length) {
+static size_t unseal_data(const sealed_secret_t* sealed_secret,
+                          uint8_t* dest,
+                          size_t dest_length) {
 #ifndef SIM_BUILD
     uint8_t* plaintext = NULL;
     size_t plaintext_size = 0;
@@ -169,11 +169,6 @@ unseal_data_error:
     // *************************************************** //
     // UNSAFE SIMULATOR-ONLY UNSEAL IMPLEMENTATION         //
     // NOT FOR PRODUCTION USE                              //
-    if (sealed_secret->blob_size > MAX_BLOB_SIZE) {
-        LOG("Sealed blob size is too large\n");
-        return SEST_ERROR;
-    }
-
     if (sealed_secret->blob_size > dest_length) {
         LOG("Unsealed data is too large\n");
         return SEST_ERROR;
@@ -255,7 +250,7 @@ bool sest_exists(char* key) {
     return exists;
 }
 
-uint8_t sest_read(char* key, uint8_t* dest, size_t dest_length) {
+size_t sest_read(char* key, uint8_t* dest, size_t dest_length) {
     LOG("Attempting to read secret for <%s>...\n", key);
 
     size_t blob_size = 0;
@@ -286,7 +281,7 @@ uint8_t sest_read(char* key, uint8_t* dest, size_t dest_length) {
         .blob = G_sealed_buffer,
     };
 
-    uint8_t unsealed_length = unseal_data(
+    size_t unsealed_length = unseal_data(
         &sealed_secret, G_unsealed_buffer, sizeof(G_unsealed_buffer));
     if (unsealed_length == SEST_ERROR) {
         LOG("Unable to read secret stored in key <%s>\n", key);

--- a/firmware/src/hal/sgx/src/trusted/secret_store.h
+++ b/firmware/src/hal/sgx/src/trusted/secret_store.h
@@ -56,7 +56,7 @@ bool sest_exists(char* key);
  *
  * @returns the length of the secret read, or ZERO upon error
  */
-uint8_t sest_read(char* key, uint8_t* dest, size_t dest_length);
+size_t sest_read(char* key, uint8_t* dest, size_t dest_length);
 
 /**
  * @brief Write a secret to the store

--- a/firmware/src/hal/sgx/src/trusted/seed.c
+++ b/firmware/src/hal/sgx/src/trusted/seed.c
@@ -71,7 +71,7 @@ bool seed_init() {
     }
 
     // Read seed
-    uint8_t seed_length = 0;
+    size_t seed_length = 0;
     if (!(seed_length = sest_read(SEST_SEED_KEY, G_seed, sizeof(G_seed)))) {
         LOG("Could not load the current seed\n");
         return false;

--- a/firmware/src/hal/sgx/test/access/test_access.c
+++ b/firmware/src/hal/sgx/test/access/test_access.c
@@ -86,7 +86,7 @@ struct {
 
 // Mock stored data for secret store
 static char G_stored_password[] = "1234567a";
-static uint8_t G_stored_password_length = 8;
+static size_t G_stored_password_length = 8;
 static uint8_t G_stored_retries = 3;
 
 // Mock implementations
@@ -102,7 +102,7 @@ bool sest_exists(char* key) {
     return false;
 }
 
-uint8_t sest_read(char* key, uint8_t* dest, size_t dest_length) {
+size_t sest_read(char* key, uint8_t* dest, size_t dest_length) {
     G_called.sest_read = true;
     G_args.sest_read.key = key;
     G_args.sest_read.dest = dest;
@@ -126,7 +126,7 @@ uint8_t sest_read(char* key, uint8_t* dest, size_t dest_length) {
             return 0;
         }
         if (dest_length >= sizeof(uint8_t)) {
-            memcpy(dest, &G_stored_retries, sizeof(uint8_t));
+            memcpy(dest, &G_stored_retries, sizeof(G_stored_retries));
             return sizeof(uint8_t);
         }
         return 0;

--- a/firmware/src/hal/sgx/test/access/test_access.c
+++ b/firmware/src/hal/sgx/test/access/test_access.c
@@ -125,9 +125,9 @@ size_t sest_read(char* key, uint8_t* dest, size_t dest_length) {
         if (G_mocks.sest_read_retries_fail) {
             return 0;
         }
-        if (dest_length >= sizeof(uint8_t)) {
+        if (dest_length >= sizeof(G_stored_retries)) {
             memcpy(dest, &G_stored_retries, sizeof(G_stored_retries));
-            return sizeof(uint8_t);
+            return sizeof(G_stored_retries);
         }
         return 0;
     }

--- a/firmware/src/hal/sgx/test/mock/mock_secret_store.c
+++ b/firmware/src/hal/sgx/test/mock/mock_secret_store.c
@@ -84,7 +84,7 @@ bool mock_sest_write(char *key, uint8_t *secret, size_t secret_length) {
     return true;
 }
 
-uint8_t mock_sest_read(char *key, uint8_t *dest, size_t dest_length) {
+size_t mock_sest_read(char *key, uint8_t *dest, size_t dest_length) {
     if (g_mock_secret_store.fail_next_read) {
         g_mock_secret_store.fail_next_read = false;
         return 0;

--- a/firmware/src/hal/sgx/test/mock/mock_secret_store.h
+++ b/firmware/src/hal/sgx/test/mock/mock_secret_store.h
@@ -69,7 +69,7 @@ bool mock_sest_write(char *key, uint8_t *secret, size_t secret_length);
  * NOTE: This mock implementation will fail if the fail_next_read flag is set,
  * regardless of the key provided.
  */
-uint8_t mock_sest_read(char *key, uint8_t *dest, size_t dest_length);
+size_t mock_sest_read(char *key, uint8_t *dest, size_t dest_length);
 
 /**
  * @brief Mock implementation of sest_remove

--- a/firmware/src/hal/sgx/test/nvmem/test_nvmem.c
+++ b/firmware/src/hal/sgx/test/nvmem/test_nvmem.c
@@ -43,7 +43,7 @@ bool sest_exists(char *key) {
     return mock_sest_exists(key);
 }
 
-uint8_t sest_read(char *key, uint8_t *dest, size_t dest_length) {
+size_t sest_read(char *key, uint8_t *dest, size_t dest_length) {
     return mock_sest_read(key, dest, dest_length);
 }
 

--- a/firmware/src/hal/sgx/test/secret_store/test_secret_store.c
+++ b/firmware/src/hal/sgx/test/secret_store/test_secret_store.c
@@ -218,7 +218,7 @@ void test_write_and_retrieve_secret() {
     // Retrieve the secret and make sure the unseal API is called with the
     // correct arguments
     uint8_t retrieved[MAX_SEST_READ_SIZE];
-    uint8_t retrieved_length = sest_read(key, retrieved, sizeof(retrieved));
+    size_t retrieved_length = sest_read(key, retrieved, sizeof(retrieved));
     assert_oe_unseal_called_with(mock.sealed_secret, mock.sealed_size, NULL, 0);
     assert(retrieved_length == mock.plaintext_size);
     ASSERT_MEMCMP(retrieved, mock.plaintext, mock.plaintext_size);
@@ -281,7 +281,7 @@ void test_read_fails_when_oe_unseal_fails() {
     mock_seal_fail_next();
     uint8_t retrieved[MAX_SEST_READ_SIZE];
     memset(retrieved, 0, sizeof(retrieved));
-    uint8_t retrieved_length = sest_read(key, retrieved, sizeof(retrieved));
+    size_t retrieved_length = sest_read(key, retrieved, sizeof(retrieved));
     assert_oe_unseal_called_with(mock.sealed_secret, mock.sealed_size, NULL, 0);
     assert(retrieved_length == SEST_ERROR);
     ASSERT_ARRAY_CLEARED(retrieved);
@@ -301,7 +301,7 @@ void test_read_fails_when_plaintext_is_too_large() {
     // The retrieved buffer is one byte too short to fit the original secret
     uint8_t retrieved[mock.plaintext_size - 1];
     memset(retrieved, 0, sizeof(retrieved));
-    uint8_t retrieved_length = sest_read(key, retrieved, sizeof(retrieved));
+    size_t retrieved_length = sest_read(key, retrieved, sizeof(retrieved));
     assert_oe_unseal_called_with(mock.sealed_secret, mock.sealed_size, NULL, 0);
     assert(retrieved_length == SEST_ERROR);
     assert(retrieved[0] == 0);
@@ -428,7 +428,7 @@ void test_read_with_invalid_key_fails() {
 
     char* invalid_key = "invalid key";
     uint8_t retrieved[MAX_SEST_READ_SIZE];
-    uint8_t retrieved_length =
+    size_t retrieved_length =
         sest_read(invalid_key, retrieved, sizeof(retrieved));
     assert_oe_unseal_not_called();
     assert(retrieved_length == SEST_ERROR);
@@ -450,7 +450,7 @@ void test_read_fails_when_kvstore_get_fails() {
     mock_ocall_kvstore_fail_next(KVSTORE_FAILURE_OE_FAILURE);
     uint8_t retrieved[MAX_SEST_READ_SIZE];
     memset(retrieved, 0, sizeof(retrieved));
-    uint8_t retrieved_length = sest_read(key, retrieved, sizeof(retrieved));
+    size_t retrieved_length = sest_read(key, retrieved, sizeof(retrieved));
     assert_oe_unseal_not_called();
     assert(retrieved_length == SEST_ERROR);
     ASSERT_ARRAY_CLEARED(retrieved);
@@ -470,7 +470,7 @@ void test_read_fails_when_blob_is_too_large() {
     assert(sest_exists(key));
     uint8_t retrieved[MAX_SEST_READ_SIZE];
     memset(retrieved, 0, sizeof(retrieved));
-    uint8_t retrieved_length = sest_read(key, retrieved, sizeof(retrieved));
+    size_t retrieved_length = sest_read(key, retrieved, sizeof(retrieved));
     assert_oe_unseal_not_called();
     assert(retrieved_length == SEST_ERROR);
     ASSERT_ARRAY_CLEARED(retrieved);
@@ -541,7 +541,7 @@ void test_read_fails_invalid_header() {
     mock_ocall_kstore_assert_value(key, mock.sealed_secret, mock.sealed_size);
 
     uint8_t retrieved[MAX_SEST_READ_SIZE] = {0};
-    uint8_t retrieved_length = sest_read(key, retrieved, sizeof(retrieved));
+    size_t retrieved_length = sest_read(key, retrieved, sizeof(retrieved));
     assert(retrieved_length == SEST_ERROR);
     ASSERT_ARRAY_CLEARED(retrieved);
 

--- a/firmware/src/hal/sgx/test/seed/test_seed.c
+++ b/firmware/src/hal/sgx/test/seed/test_seed.c
@@ -125,7 +125,7 @@ bool sest_exists(char *key) {
     return mock_sest_exists(key);
 }
 
-uint8_t sest_read(char *key, uint8_t *dest, size_t dest_length) {
+size_t sest_read(char *key, uint8_t *dest, size_t dest_length) {
     return mock_sest_read(key, dest, dest_length);
 }
 


### PR DESCRIPTION
- The `sest_read` function now returns a `size_t` value, for consistency with all other SGX HAL interfaces
- Updated dependent uses
- Updated unit tests