### PR TITLE
Version 5.2.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [5.2.6] - 20/07/2026
 
+### Features/enhancements
+
 - Pinned middleware docker image apt sources to snapshot.debian.org
 - Added copilot instructions for code reviewing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.2.6] - 20/07/2026
+
+- Pinned middleware docker image apt sources to snapshot.debian.org
+- Added copilot instructions for code reviewing
+
+### Fixes
+
+- Fixed logic in block utils' BLOCK_ALREADY_VALID() macro
+
 ## [5.2.5] - 03/10/2025
 
 ### Fixes

--- a/firmware/src/ledger/ui/src/defs.h
+++ b/firmware/src/ledger/ui/src/defs.h
@@ -31,6 +31,6 @@
 // Version and patchlevel
 #define VERSION_MAJOR 0x05
 #define VERSION_MINOR 0x02
-#define VERSION_PATCH 0x05
+#define VERSION_PATCH 0x06
 
 #endif // __DEFS_H

--- a/firmware/src/ledger/ui/test/onboard/test_onboard.c
+++ b/firmware/src/ledger/ui/test/onboard/test_onboard.c
@@ -313,11 +313,11 @@ void test_is_onboarded() {
 
     G_device_onboarded = true;
     assert(5 == is_onboarded());
-    ASSERT_APDU("\x80\x01\x05\x02\x05");
+    ASSERT_APDU("\x80\x01\x05\x02\x06");
 
     G_device_onboarded = false;
     assert(5 == is_onboarded());
-    ASSERT_APDU("\x80\x00\x05\x02\x05");
+    ASSERT_APDU("\x80\x00\x05\x02\x06");
 }
 
 int main() {

--- a/firmware/src/powhsm/src/defs.h
+++ b/firmware/src/powhsm/src/defs.h
@@ -30,6 +30,6 @@
 // Version and patchlevel
 #define VERSION_MAJOR 0x05
 #define VERSION_MINOR 0x02
-#define VERSION_PATCH 0x05
+#define VERSION_PATCH 0x06
 
 #endif // __DEFS_H

--- a/middleware/ledger/protocol.py
+++ b/middleware/ledger/protocol.py
@@ -37,8 +37,8 @@ from comm.bitcoin import get_unsigned_tx, get_tx_hash
 
 class HSM2ProtocolLedger(HSM2Protocol):
     # Current manager supported versions for HSM UI and HSM SIGNER (<=)
-    UI_VERSION = HSM2FirmwareVersion(5, 2, 5)
-    APP_VERSION = HSM2FirmwareVersion(5, 2, 5)
+    UI_VERSION = HSM2FirmwareVersion(5, 2, 6)
+    APP_VERSION = HSM2FirmwareVersion(5, 2, 6)
 
     # Amount of time to wait to make sure the app is opened
     OPEN_APP_WAIT = 1  # second

--- a/middleware/tests/ledger/test_protocol.py
+++ b/middleware/tests/ledger/test_protocol.py
@@ -49,7 +49,7 @@ class TestHSM2ProtocolLedger(TestCase):
         self.dongle.disconnect = Mock()
         self.dongle.is_onboarded = Mock(return_value=True)
         self.dongle.get_current_mode = Mock(return_value=HSM2Dongle.MODE.SIGNER)
-        self.dongle.get_version = Mock(return_value=HSM2FirmwareVersion(5, 2, 5))
+        self.dongle.get_version = Mock(return_value=HSM2FirmwareVersion(5, 2, 6))
         self.dongle.get_signer_parameters = Mock(return_value=Mock(
             min_required_difficulty=123))
         self.protocol = HSM2ProtocolLedger(self.pin, self.dongle)

--- a/middleware/tests/ledger/test_protocol_v1.py
+++ b/middleware/tests/ledger/test_protocol_v1.py
@@ -47,7 +47,7 @@ class TestHSM1ProtocolLedger(TestCase):
         self.dongle.disconnect = Mock()
         self.dongle.is_onboarded = Mock(return_value=True)
         self.dongle.get_current_mode = Mock(return_value=HSM2Dongle.MODE.SIGNER)
-        self.dongle.get_version = Mock(return_value=HSM2FirmwareVersion(5, 2, 5))
+        self.dongle.get_version = Mock(return_value=HSM2FirmwareVersion(5, 2, 6))
         self.dongle.get_signer_parameters = Mock(return_value=Mock(
             min_required_difficulty=123))
         self.protocol = HSM1ProtocolLedger(self.pin, self.dongle)


### PR DESCRIPTION
- Bump version to 5.2.6
- Updated version references in firmware, middleware and unit tests
- Updated CHANGELOG