### PR TITLE
Move ancestor information into RAM

### DIFF
--- a/docs/blockchain-bookkeeping.md
+++ b/docs/blockchain-bookkeeping.md
@@ -16,10 +16,13 @@ An *initialized* powHSM device must store the following state information in non
 
 - `best_block` (32 bytes - byte array): The current known best block with sufficient confirmations.
 - `newest_valid_block` (32 bytes - byte array): The newest valid block known, regardless of confirmations.
+
+Additionally, a powHSM device must store the following block ancestry information that needn't necessarily reside in non-volatile memory.
+
 - `ancestor_block` (32 bytes - byte array): The current inclusion process' proved ancestor block.
 - `ancestor_receipts_root` (32 bytes - byte array): The current inclusion process' proved ancestor block's receipts root.
 
-Additionally, a powHSM device must store the following mid-state information about the blockchain state, which needn't necessarily be kept in non-volatile memory. We call this transitional information `blockchain_state.updating` collectively. The `.` (dot) notation in variable names below is just a way of grouping related variables together.
+Finally, a powHSM device must store the following mid-state information about the blockchain state, which also needn't necessarily be kept in non-volatile memory. We call this transitional information `blockchain_state.updating` collectively. The `.` (dot) notation in variable names below is just a way of grouping related variables together.
 
 - `updating.in_progress` (1 byte - boolean).
 - `updating.already_validated` (1 byte - boolean).
@@ -29,7 +32,7 @@ Additionally, a powHSM device must store the following mid-state information abo
 - `updating.best_block` (32 bytes - byte array): The current update process' new best block hash.
 - `updating.newest_valid_block` (32 bytes - byte array): The current update process' newest valid block hash.
 
-The total amount of information needed to represent an instance of `blockchain_state` is thus 263 bytes, of which only 128 bytes are to be mandatorily stored in non-volatile memory. It is very important to note that any optimizations with respect to the representation and storage of these values can be done as long as the underlying semantics are not jeopardized. For example, saving 2 bytes (for a total of 261 bytes instead of 263) is possible if a single flag-like byte is used for the boolean state variables.
+The total amount of information needed to represent an instance of `blockchain_state` is thus 263 bytes, of which only 64 bytes are to be mandatorily stored in non-volatile memory. It is very important to note that any optimizations with respect to the representation and storage of these values can be done as long as the underlying semantics are not jeopardized. For example, saving 2 bytes (for a total of 261 bytes instead of 263) is possible if a single flag-like byte is used for the boolean state variables.
 
 At any point in time, `best_block` is the hash of the currently best known and sufficiently confirmed block by the powHSM device. This "sufficiently confirmed" condition implies an underlying assumption that such block will always be part of the main chain.
 
@@ -37,7 +40,7 @@ The `newest_valid_block` is used for optimization in terms of Proof Of Work vali
 
 The `updating.*` variables are used as mid-state for the blockchain updating routine.
 
-At any point in time, the `ancestor_block` is the hash of any ancestor block to `best_block` that was proved to be in the blockchain by the inclusion verification process depicted further down in this document; and `ancestor_receipts_root` is the receipts trie root of that same block.
+At any point in time, the `ancestor_block` is the hash of any ancestor block to `best_block` that was proved to be in the blockchain by the inclusion verification process depicted further down in this document; and `ancestor_receipts_root` is the receipts trie root of that same block. Both values can also simultaneously contain zeroes, representing an unset ancestry state (see below).
 
 ### Initialization
 

--- a/firmware/src/powhsm/src/auth_trie.c
+++ b/firmware/src/powhsm/src/auth_trie.c
@@ -239,9 +239,9 @@ unsigned int auth_sign_handle_merkleproof(volatile unsigned int rx) {
                 // If this is the root, check it matches the current
                 // bc state's ancestor receipts root
                 if (auth.trie.current_node == auth.trie.total_nodes) {
-                    if (!memcmp(N_bc_state.ancestor_receipt_root,
+                    if (!memcmp(bc_st_ancestor.receipt_root,
                                 auth.trie.node_hash,
-                                sizeof(N_bc_state.ancestor_receipt_root))) {
+                                sizeof(bc_st_ancestor.receipt_root))) {
                         auth_transition_to(STATE_AUTH_SIGN);
                         return 0;
                     }

--- a/firmware/src/powhsm/src/bc_ancestor.c
+++ b/firmware/src/powhsm/src/bc_ancestor.c
@@ -61,7 +61,7 @@ static uint8_t expected_state;
  * Update ancestor prologue: call once we have the first block's hash.
  */
 static void bc_upd_ancestor_prologue() {
-    if (HNEQ(block.block_hash, N_bc_state.ancestor_block) &&
+    if (HNEQ(block.block_hash, bc_st_ancestor.block_hash) &&
         HNEQ(block.block_hash, N_bc_state.best_block)) {
         FAIL(ANCESTOR_TIP_MISMATCH);
     }
@@ -71,8 +71,8 @@ static void bc_upd_ancestor_prologue() {
  * State updates to perform when successfully updated ancestor.
  */
 static void bc_upd_ancestor_success() {
-    NVM_WRITE(N_bc_state.ancestor_block, block.block_hash, HASH_SIZE);
-    NVM_WRITE(N_bc_state.ancestor_receipt_root, block.receipt_root, HASH_SIZE);
+    HSTORE(bc_st_ancestor.block_hash, block.block_hash);
+    HSTORE(bc_st_ancestor.receipt_root, block.receipt_root);
 }
 
 // -----------------------------------------------------------------------

--- a/firmware/src/powhsm/src/bc_state.c
+++ b/firmware/src/powhsm/src/bc_state.c
@@ -95,6 +95,7 @@ void bc_init_state() {
 void bc_backup_partial_state() {
     bc_state_backup_t backup;
 
+    explicit_bzero(&backup, sizeof(backup));
     backup.valid = 1;
     SAFE_MEMMOVE(&backup.data.updating,
                  sizeof(backup.data.updating),

--- a/firmware/src/powhsm/src/bc_state.c
+++ b/firmware/src/powhsm/src/bc_state.c
@@ -65,16 +65,25 @@ void bc_init_state() {
     }
 
     explicit_bzero(&bc_st_updating, sizeof(bc_st_updating));
-    if (N_bc_state_updating_backup.valid) {
+    explicit_bzero(&bc_st_ancestor, sizeof(bc_st_ancestor));
+    if (N_bc_state_backup.valid) {
         uint8_t f = 0;
-        NVM_WRITE(&N_bc_state_updating_backup.valid, &f, sizeof(f));
+        NVM_WRITE(&N_bc_state_backup.valid, &f, sizeof(f));
         SAFE_MEMMOVE(&bc_st_updating,
                      sizeof(bc_st_updating),
                      MEMMOVE_ZERO_OFFSET,
-                     &N_bc_state_updating_backup.data,
-                     sizeof(N_bc_state_updating_backup.data),
+                     &N_bc_state_backup.data.updating,
+                     sizeof(N_bc_state_backup.data.updating),
                      MEMMOVE_ZERO_OFFSET,
-                     sizeof(N_bc_state_updating_backup.data),
+                     sizeof(N_bc_state_backup.data.updating),
+                     { return; });
+        SAFE_MEMMOVE(&bc_st_ancestor,
+                     sizeof(bc_st_ancestor),
+                     MEMMOVE_ZERO_OFFSET,
+                     &N_bc_state_backup.data.ancestor,
+                     sizeof(N_bc_state_backup.data.ancestor),
+                     MEMMOVE_ZERO_OFFSET,
+                     sizeof(N_bc_state_backup.data.ancestor),
                      { return; });
     }
 }
@@ -84,23 +93,27 @@ void bc_init_state() {
  * to NVM
  */
 void bc_backup_partial_state() {
-    bc_state_updating_backup_t backup;
+    bc_state_backup_t backup;
 
-    if (bc_st_updating.in_progress) {
-        backup.valid = 1;
-        SAFE_MEMMOVE(&backup.data,
-                     sizeof(backup.data),
-                     MEMMOVE_ZERO_OFFSET,
-                     &bc_st_updating,
-                     sizeof(bc_st_updating),
-                     MEMMOVE_ZERO_OFFSET,
-                     sizeof(bc_st_updating),
-                     { return; });
+    backup.valid = 1;
+    SAFE_MEMMOVE(&backup.data.updating,
+                 sizeof(backup.data.updating),
+                 MEMMOVE_ZERO_OFFSET,
+                 &bc_st_updating,
+                 sizeof(bc_st_updating),
+                 MEMMOVE_ZERO_OFFSET,
+                 sizeof(bc_st_updating),
+                 { return; });
+    SAFE_MEMMOVE(&backup.data.ancestor,
+                 sizeof(backup.data.ancestor),
+                 MEMMOVE_ZERO_OFFSET,
+                 &bc_st_ancestor,
+                 sizeof(bc_st_ancestor),
+                 MEMMOVE_ZERO_OFFSET,
+                 sizeof(bc_st_ancestor),
+                 { return; });
 
-        NVM_WRITE(&N_bc_state_updating_backup,
-                  &backup,
-                  sizeof(N_bc_state_updating_backup));
-    }
+    NVM_WRITE(&N_bc_state_backup, &backup, sizeof(N_bc_state_backup));
 }
 
 // -----------------------------------------------------------------------
@@ -111,7 +124,7 @@ void bc_backup_partial_state() {
 NON_VOLATILE bc_state_t N_bc_state_var;
 
 // Non-volatile intermediate advance blockchain state backup
-NON_VOLATILE bc_state_updating_backup_t N_bc_state_updating_backup_var;
+NON_VOLATILE bc_state_backup_t N_bc_state_backup_var;
 
 /*
  * Dump hash corresponding to hash_codes[hash_ix] to APDU.
@@ -127,10 +140,10 @@ uint8_t dump_hash(uint8_t hash_code) {
         h = N_bc_state.newest_valid_block;
         break;
     case ANCESTOR_BLOCK:
-        h = N_bc_state.ancestor_block;
+        h = bc_st_ancestor.block_hash;
         break;
     case ANCESTOR_RECEIPT_ROOT:
-        h = N_bc_state.ancestor_receipt_root;
+        h = bc_st_ancestor.receipt_root;
         break;
     case U_BEST_BLOCK:
         h = bc_st_updating.best_block;

--- a/firmware/src/powhsm/src/bc_state.h
+++ b/firmware/src/powhsm/src/bc_state.h
@@ -44,12 +44,15 @@
 typedef struct {
     uint8_t best_block[HASH_SIZE];
     uint8_t newest_valid_block[HASH_SIZE];
-    uint8_t ancestor_block[HASH_SIZE];
-    uint8_t ancestor_receipt_root[HASH_SIZE];
     uint8_t last_auth_signed_btc_tx_hash[HASH_SIZE];
 
     uint8_t initialized;
 } bc_state_t;
+
+typedef struct {
+    uint8_t block_hash[HASH_SIZE];
+    uint8_t receipt_root[HASH_SIZE];
+} bc_state_ancestor_t;
 
 typedef struct {
     uint8_t next_expected_block[HASH_SIZE];
@@ -63,15 +66,17 @@ typedef struct {
 
 typedef struct {
     uint8_t valid;
-    bc_state_updating_t data;
-} bc_state_updating_backup_t;
+    struct {
+        bc_state_updating_t updating;
+        bc_state_ancestor_t ancestor;
+    } data;
+} bc_state_backup_t;
 
 extern NON_VOLATILE bc_state_t N_bc_state_var;
 #define N_bc_state (*(bc_state_t*)PIC(&N_bc_state_var))
 
-extern NON_VOLATILE bc_state_updating_backup_t N_bc_state_updating_backup_var;
-#define N_bc_state_updating_backup \
-    (*(bc_state_updating_backup_t*)PIC(&N_bc_state_updating_backup_var))
+extern NON_VOLATILE bc_state_backup_t N_bc_state_backup_var;
+#define N_bc_state_backup (*(bc_state_backup_t*)PIC(&N_bc_state_backup_var))
 
 #ifndef PARAM_INITIAL_BLOCK_HASH
 #include "defs.h"

--- a/firmware/src/powhsm/src/mem.h
+++ b/firmware/src/powhsm/src/mem.h
@@ -55,6 +55,7 @@ typedef union {
 
 typedef struct {
     bc_state_updating_t bc_st_updating;
+    bc_state_ancestor_t bc_st_ancestor;
 } sess_per_mem_t;
 
 extern mem_t mem;
@@ -63,6 +64,7 @@ extern sess_per_mem_t sess_per_mem;
 #define block (mem.block)
 #define aux_bc_st (mem.aux_bc_st)
 #define bc_st_updating (sess_per_mem.bc_st_updating)
+#define bc_st_ancestor (sess_per_mem.bc_st_ancestor)
 #define auth (mem.auth)
 #define attestation (mem.att)
 #define heartbeat (mem.heartbeat)

--- a/firmware/src/sgx/src/trusted/system.c
+++ b/firmware/src/sgx/src/trusted/system.c
@@ -271,10 +271,10 @@ bool system_init(unsigned char* msg_buffer, size_t msg_buffer_size) {
         LOG("Error registering bcstate block\n");
         return false;
     }
-    if (!nvmem_register_block("bcstate_updating",
-                              &N_bc_state_updating_backup_var,
-                              sizeof(N_bc_state_updating_backup_var))) {
-        LOG("Error registering bcstate_updating block\n");
+    if (!nvmem_register_block("bcstate_backup",
+                              &N_bc_state_backup_var,
+                              sizeof(N_bc_state_backup_var))) {
+        LOG("Error registering bcstate_backup block\n");
         return false;
     }
 

--- a/firmware/src/sgx/test/system/test_system.c
+++ b/firmware/src/sgx/test/system/test_system.c
@@ -176,7 +176,7 @@ static mock_data_t G_mock_data;
 
 // Globals
 bc_state_t N_bc_state_var;
-bc_state_updating_backup_t N_bc_state_updating_backup_var;
+bc_state_backup_t N_bc_state_backup_var;
 static try_context_t G_try_last_open_context_var;
 try_context_t* G_try_last_open_context = &G_try_last_open_context_var;
 unsigned char G_io_apdu_buffer[IO_APDU_BUFFER_SIZE];
@@ -430,9 +430,9 @@ void test_init_success() {
                        sizeof(N_bc_state_var));
     ASSERT_CALLED_WITH(nvmem_register_block,
                        1,
-                       "bcstate_updating",
-                       &N_bc_state_updating_backup_var,
-                       sizeof(N_bc_state_updating_backup_var));
+                       "bcstate_backup",
+                       &N_bc_state_backup_var,
+                       sizeof(N_bc_state_backup_var));
     assert(NUM_CALLS(nvmem_load) == 1);
     assert(NUM_CALLS(hsm_init) == 1);
     assert(NUM_CALLS(hsm_set_external_processor) == 1);
@@ -606,7 +606,7 @@ void test_init_fails_when_nvmem_register_block_fails() {
                        sizeof(N_bc_state_var));
     ASSERT_NOT_CALLED(upgrade_init);
 
-    FORCE_NVMEM_FAIL_ON_KEY("bcstate_updating");
+    FORCE_NVMEM_FAIL_ON_KEY("bcstate_backup");
     assert(!system_init(G_io_apdu_buffer, sizeof(G_io_apdu_buffer)));
     assert(NUM_CALLS(oe_is_outside_enclave) == 2);
     assert(NUM_CALLS(sest_init) == 2);
@@ -624,9 +624,9 @@ void test_init_fails_when_nvmem_register_block_fails() {
                        sizeof(N_bc_state_var));
     ASSERT_CALLED_WITH(nvmem_register_block,
                        2,
-                       "bcstate_updating",
-                       &N_bc_state_updating_backup_var,
-                       sizeof(N_bc_state_updating_backup_var));
+                       "bcstate_backup",
+                       &N_bc_state_backup_var,
+                       sizeof(N_bc_state_backup_var));
     ASSERT_NOT_CALLED(upgrade_init);
 
     teardown();
@@ -655,9 +655,9 @@ void test_init_fails_when_nvmem_load_fails() {
                        sizeof(N_bc_state_var));
     ASSERT_CALLED_WITH(nvmem_register_block,
                        1,
-                       "bcstate_updating",
-                       &N_bc_state_updating_backup_var,
-                       sizeof(N_bc_state_updating_backup_var));
+                       "bcstate_backup",
+                       &N_bc_state_backup_var,
+                       sizeof(N_bc_state_backup_var));
     ASSERT_NOT_CALLED(upgrade_init);
 
     teardown();

--- a/firmware/src/tcpsigner/src/hsmsim_admin.c
+++ b/firmware/src/tcpsigner/src/hsmsim_admin.c
@@ -29,6 +29,7 @@
 #include "hsmsim_admin.h"
 #include "apdu.h"
 #include "bc_state.h"
+#include "mem.h"
 #include "ints.h"
 
 static hsmsim_admin_data_t hsmsim_admin_data;
@@ -87,12 +88,12 @@ unsigned int hsmsim_admin_process_apdu(unsigned int rx) {
             return hsmsim_admin_error(HSMSIM_ADMIN_ERROR_DATA_SIZE);
         }
         memcpy(hsmsim_admin_data.old_ancestor_receipts_root,
-               N_bc_state.ancestor_receipt_root,
+               bc_st_ancestor.receipt_root,
                HASH_LENGTH);
-        memcpy(N_bc_state.ancestor_receipt_root, APDU_DATA_PTR, HASH_LENGTH);
+        memcpy(bc_st_ancestor.receipt_root, APDU_DATA_PTR, HASH_LENGTH);
         hsmsim_admin_data.ancestor_receipts_root_set = true;
         LOG_HEX("ADMIN: Ancestor receipts root set to",
-                N_bc_state.ancestor_receipt_root,
+                bc_st_ancestor.receipt_root,
                 HASH_LENGTH);
         tx = TX_FOR_DATA_SIZE(0);
         break;
@@ -101,12 +102,12 @@ unsigned int hsmsim_admin_process_apdu(unsigned int rx) {
             LOG("ADMIN: Cannot reset ancestor receipts root: not set.\n");
             return hsmsim_admin_error(HSMSIM_ADMIN_ERROR_INVALID_STATE);
         }
-        memcpy(N_bc_state.ancestor_receipt_root,
+        memcpy(bc_st_ancestor.receipt_root,
                hsmsim_admin_data.old_ancestor_receipts_root,
                HASH_LENGTH);
         hsmsim_admin_data.ancestor_receipts_root_set = false;
         LOG_HEX("ADMIN: Ancestor receipts root reset to",
-                N_bc_state.ancestor_receipt_root,
+                bc_st_ancestor.receipt_root,
                 HASH_LENGTH);
         tx = TX_FOR_DATA_SIZE(0);
         break;
@@ -155,10 +156,10 @@ unsigned int hsmsim_admin_process_apdu(unsigned int rx) {
         // and update ancestor operations testing, so we backup and restore
         // the whole lot
         memcpy(hsmsim_admin_data.old_ancestor_block,
-               N_bc_state.ancestor_block,
+               bc_st_ancestor.block_hash,
                HASH_LENGTH);
         memcpy(hsmsim_admin_data.old_ancestor_receipts_root,
-               N_bc_state.ancestor_receipt_root,
+               bc_st_ancestor.receipt_root,
                HASH_LENGTH);
         memcpy(hsmsim_admin_data.old_best_block,
                N_bc_state.best_block,
@@ -177,10 +178,10 @@ unsigned int hsmsim_admin_process_apdu(unsigned int rx) {
         memcpy(N_bc_state.best_block,
                hsmsim_admin_data.old_best_block,
                HASH_LENGTH);
-        memcpy(N_bc_state.ancestor_block,
+        memcpy(bc_st_ancestor.block_hash,
                hsmsim_admin_data.old_ancestor_block,
                HASH_LENGTH);
-        memcpy(N_bc_state.ancestor_receipt_root,
+        memcpy(bc_st_ancestor.receipt_root,
                hsmsim_admin_data.old_ancestor_receipts_root,
                HASH_LENGTH);
         hsmsim_admin_data.best_block_set = false;

--- a/firmware/test/options.py
+++ b/firmware/test/options.py
@@ -92,6 +92,14 @@ class OptionParser:
             help="Perform device unlock manually (defaults to no)",
         )
         parser.add_argument(
+            "-u",
+            "--unlock-at-start",
+            dest="unlock_at_start",
+            action="store_true",
+            default=False,
+            help="Perform an initial device unlock (defaults to no)",
+        )
+        parser.add_argument(
             "-v",
             "--verbose",
             dest="verbose",

--- a/firmware/test/run.py
+++ b/firmware/test/run.py
@@ -27,6 +27,7 @@ from ledger.hsm2dongle import HSM2Dongle
 from ledger.hsm2dongle_tcp import HSM2DongleTCP
 from sgx.hsm2dongle import HSM2DongleSGX
 import output
+import time
 
 import logging
 
@@ -58,6 +59,9 @@ if __name__ == "__main__":
                 raise RuntimeError("Auto unlock requires 'pin' argument")
             run_args[TestCase.RUN_ARGS_MANUAL_KEY] = options.manual_unlock
             run_args[TestCase.RUN_ARGS_PIN_KEY] = options.pin
+
+        if options.unlock_at_start and options.pin is None:
+            raise RuntimeError("Unlock at start requires 'pin' argument")
 
         if options.device == "ledger":
             dongle = HSM2Dongle(options.dongle_verbose)
@@ -96,6 +100,27 @@ if __name__ == "__main__":
         version = dongle.get_version()
         output.ok()
         output.info(f"Version: {version}", nl=True)
+
+        if options.unlock_at_start:
+            curr_mode = dongle.get_current_mode()
+            output.info("Unlocking device")
+            if curr_mode == HSM2Dongle.MODE.BOOTLOADER:
+                if not dongle.unlock(options.pin.encode()):
+                    raise RuntimeError("Failed to unlock device")
+                try:
+                    dongle.exit_menu(autoexec=True)
+                except Exception:
+                    # exit_menu() always throws in Ledger due to
+                    # USB disconnection. we don't care
+                    pass
+                output.ok()
+                # Reconnect (for Ledger)
+                dongle.disconnect()
+                time.sleep(3)
+                dongle.connect()
+            else:
+                output.info(" -- Already unlocked?")
+                output.skipped()
 
         output.header("Running tests")
         tests_passed = suite.run(dongle, run_on, run_args)

--- a/firmware/test/test-all
+++ b/firmware/test/test-all
@@ -37,7 +37,7 @@ elif [[ "$1" == "sgx" ]]; then
 elif [[ "$1" == "sgxsim" ]]; then
     WITH_DEVICE="no"
     PIN=1234abcd
-    RUN_ARGS="-dsgxsim -shost.docker.internal -p7777 -P $PIN"
+    RUN_ARGS="-dsgxsim -shost.docker.internal -p7777 -P $PIN -u"
     PLATFORM="sgx"
 elif [[ "$1" != "" ]]; then
     echo -e "\e[1;31mInvalid or unknown option '$1'. Issue '$0 help' for help.\e[0m"
@@ -59,9 +59,8 @@ if [[ "$WITH_DEVICE" == "no" ]]; then
         $TEST_ROOT/../../docker/sgx/do-notty /hsm2/firmware/src/sgx/bin "./hsmsgx ./hsmsgx_enclave.signed -b 0.0.0.0" > /dev/null &
         sleep 1
 
-        ## Onboard and unlock the powHSM
+        ## Onboard the powHSM
         $TEST_ROOT/../../docker/mware/do-notty-nousb /hsm2/firmware/test/scripts ./onboard-sgx host.docker.internal $PIN
-        $TEST_ROOT/../../docker/mware/do-notty-nousb /hsm2/middleware python adm_sgx.py unlock -shost.docker.internal --pin $PIN
 
         ## Run tests
         $TEST_ROOT/../../docker/mware/do-notty-nousb /hsm2/firmware/test "python run.py ${RUN_ARGS}"


### PR DESCRIPTION
- Ancestor block hash and ancestor receipts root hash moved from NVM to RAM
- Updated references
- Updated signer exit backup scheme to include ancestor information
- SGX NVM backup key updated accordingly
- Fixed failing unit tests
- Updated blockchain bookkeeping documentation
- Added unlocking at startup for firmware test suite
- Using unlock at start for automatic SGX simulator test bootstrap script
