### PR TITLE
SGX debug mode attestation warnings and migration disallowance

### DIFF
--- a/firmware/build/extract-mrenclave
+++ b/firmware/build/extract-mrenclave
@@ -45,13 +45,13 @@ if [[ ! -f $ENCLAVE_BIN ]]; then
     echo "Invalid enclave path: $ENCLAVE_BIN"
     exit 1
 else
-    ENCLAVE_ARG="-e $ENCLAVE_BIN"
+    ENCLAVE_ARG="-e '$ENCLAVE_BIN'"
 fi
 
 if [[ $ENCLAVE_BIN == *.signed ]]; then
     CONFIG_ARG=""
 elif [[ $# -ge 2 ]]; then
-    CONFIG_ARG="-c $(realpath $2 --relative-to=$HSM_ROOT)"
+    CONFIG_ARG="-c '$(realpath $2 --relative-to=$HSM_ROOT)'"
 else
     echo "Invalid usage"
     print_usage

--- a/firmware/build/extract-mrenclave
+++ b/firmware/build/extract-mrenclave
@@ -60,7 +60,8 @@ fi
 
 DIGEST_CMD="oesign digest $ENCLAVE_ARG $CONFIG_ARG -d /tmp/enclave_digest > /dev/null && hexdump -v -e '/1 \"%02x\"' /tmp/enclave_digest"
 MRENCLAVE_CMD="oesign dump $ENCLAVE_ARG | grep mrenclave | cut -d '=' -f 2"
-EXTRACT_CMD="\$SGX_ENVSETUP && echo digest: \$($DIGEST_CMD) && echo mrenclave: \$($MRENCLAVE_CMD)"
+MRSIGNER_CMD="oesign dump $ENCLAVE_ARG | grep mrsigner | cut -d '=' -f 2"
+EXTRACT_CMD="\$SGX_ENVSETUP && echo digest: \$($DIGEST_CMD) && echo mrenclave: \$($MRENCLAVE_CMD) && echo mrsigner: \$($MRSIGNER_CMD)"
 
 DOCKER_USER="$(id -u):$(id -g)"
 

--- a/firmware/src/hal/sgx/test/mock/openenclave/common.h
+++ b/firmware/src/hal/sgx/test/mock/openenclave/common.h
@@ -217,13 +217,21 @@ typedef struct _sgx_quote_auth_data {
             0x64, 0x4d, 0x0e, 0xf8, 0x9a                                  \
     }
 
+// Taken from OpenEnclave's include/openenclave/bits/report.h
+
+#define OE_REPORT_ATTRIBUTES_DEBUG 0x0000000000000001ULL
+
 // Taken from OpenEnclave's include/openenclave/bits/evidence.h
 
 #define OE_UUID_SIZE 16
 
 #define OE_CLAIM_UNIQUE_ID "unique_id"
 
+#define OE_CLAIM_ATTRIBUTES "attributes"
+
 #define OE_CLAIM_CUSTOM_CLAIMS_BUFFER "custom_claims_buffer"
+
+#define OE_EVIDENCE_ATTRIBUTES_SGX_DEBUG OE_REPORT_ATTRIBUTES_DEBUG
 
 typedef struct _oe_uuid_t {
     uint8_t b[OE_UUID_SIZE];

--- a/firmware/src/hal/sgx/test/mock/openenclave/common.h
+++ b/firmware/src/hal/sgx/test/mock/openenclave/common.h
@@ -284,6 +284,8 @@ typedef enum _oe_enclave_type {
 
 // Taken from OpenEnclave's include/openenclave/host.h
 
+#define OE_ENCLAVE_FLAG_DEBUG 0x00000001u
+
 typedef enum _oe_enclave_setting_type {
     OE_ENCLAVE_SETTING_CONTEXT_SWITCHLESS = 0xdc73a628,
 #ifdef OE_WITH_EXPERIMENTAL_EEID

--- a/firmware/src/sgx/src/trusted/upgrade.c
+++ b/firmware/src/sgx/src/trusted/upgrade.c
@@ -95,8 +95,10 @@ typedef enum {
     ERR_UPGRADE_INTERNAL = 0x6A99,
 } err_code_upgrade_t;
 
-// MRENCLAVE size
+// MRENCLAVE and ATTRIBUTES sizes (and type)
 #define UPGRADE_MRENCLAVE_SIZE HASH_LENGTH
+#define UPGRADE_ATTRIBUTES_TYPE uint64_t
+#define UPGRADE_ATTRIBUTES_SIZE (sizeof(UPGRADE_ATTRIBUTES_TYPE))
 
 // SGX upgrade spec
 typedef struct {
@@ -625,6 +627,22 @@ unsigned int upgrade_process_apdu(volatile unsigned int rx) {
                    UPGRADE_MRENCLAVE_SIZE) != 0) {
             LOG("Peer enclave's mrenclave does not match the spec's "
                 "mrenclave\n");
+            goto upgrade_process_apdu_identify_peer_error;
+        }
+        if (!(claim = evidence_get_claim(
+                  claims, claims_size, OE_CLAIM_ATTRIBUTES))) {
+            LOG("Error extracting peer enclave's attributes\n");
+            goto upgrade_process_apdu_identify_peer_error;
+        }
+        // Here, the claim value (containing the attributes) is cast
+        // directly to the attributes type since in the claim generation
+        // (see OpenEnclave source), there's no specific marshalling code.
+        // This is probably fine given that the underlying platform is assumed
+        // to be Intel SGX in both exporter and importer cases.
+        if (claim->value_size != UPGRADE_ATTRIBUTES_SIZE ||
+            (*((UPGRADE_ATTRIBUTES_TYPE*)claim->value) &
+             OE_EVIDENCE_ATTRIBUTES_SGX_DEBUG)) {
+            LOG("Peer enclave is running in debug mode\n");
             goto upgrade_process_apdu_identify_peer_error;
         }
         if (!(claim = evidence_get_custom_claim(claims, claims_size))) {

--- a/firmware/src/sgx/src/untrusted/enclave_provider.c
+++ b/firmware/src/sgx/src/untrusted/enclave_provider.c
@@ -29,10 +29,12 @@
 #include "log.h"
 
 // Simulation build
-#ifndef SIM_BUILD
-#define CREATE_ENCLAVE_FLAGS 0
-#else
+#if defined(DEBUG_BUILD)
+#define CREATE_ENCLAVE_FLAGS OE_ENCLAVE_FLAG_DEBUG
+#elif defined(SIM_BUILD)
 #define CREATE_ENCLAVE_FLAGS OE_ENCLAVE_FLAG_SIMULATE
+#else
+#define CREATE_ENCLAVE_FLAGS 0
 #endif
 
 // Global pointer to the enclave. This should be the only global pointer to the

--- a/firmware/src/sgx/test/common/hsm_u.h
+++ b/firmware/src/sgx/test/common/hsm_u.h
@@ -27,6 +27,8 @@
 
 #include <openenclave/host.h>
 
+#define OE_ENCLAVE_FLAG_DEBUG 123
+
 oe_result_t oe_create_hsm_enclave(const char* path,
                                   oe_enclave_type_t type,
                                   uint32_t flags,

--- a/firmware/src/sgx/test/common/hsm_u.h
+++ b/firmware/src/sgx/test/common/hsm_u.h
@@ -27,8 +27,6 @@
 
 #include <openenclave/host.h>
 
-#define OE_ENCLAVE_FLAG_DEBUG 123
-
 oe_result_t oe_create_hsm_enclave(const char* path,
                                   oe_enclave_type_t type,
                                   uint32_t flags,

--- a/firmware/src/sgx/test/enclave_provider/test_enclave_provider.c
+++ b/firmware/src/sgx/test/enclave_provider/test_enclave_provider.c
@@ -164,7 +164,7 @@ void test_epro_get_enclave_first_call_success() {
     assert(G_called.oe_create_hsm_enclave_called == true);
     assert(strcmp(G_called.last_create_enclave_path, test_path) == 0);
     assert(G_called.last_enclave_type == OE_ENCLAVE_TYPE_AUTO);
-    assert(G_called.last_enclave_flags == 123);
+    assert(G_called.last_enclave_flags == 1);
     assert(G_called.last_setting_count == 0);
 }
 

--- a/firmware/src/sgx/test/enclave_provider/test_enclave_provider.c
+++ b/firmware/src/sgx/test/enclave_provider/test_enclave_provider.c
@@ -164,7 +164,7 @@ void test_epro_get_enclave_first_call_success() {
     assert(G_called.oe_create_hsm_enclave_called == true);
     assert(strcmp(G_called.last_create_enclave_path, test_path) == 0);
     assert(G_called.last_enclave_type == OE_ENCLAVE_TYPE_AUTO);
-    assert(G_called.last_enclave_flags == 0);
+    assert(G_called.last_enclave_flags == 123);
     assert(G_called.last_setting_count == 0);
 }
 

--- a/firmware/src/sgx/test/upgrade/Makefile
+++ b/firmware/src/sgx/test/upgrade/Makefile
@@ -22,7 +22,7 @@
 
 include ../common/common.mk
 
-CFLAGS += -DPARAM_SIGNERS_FILE=testing
+CFLAGS += -DPARAM_SIGNERS_FILE=testing #-DENCLAVE_LOGS
 VPATH += $(HALSGXSRCDIR)
 LIBS = -lsecp256k1 -lmbedcrypto
 

--- a/firmware/src/sgx/test/upgrade/test_upgrade.c
+++ b/firmware/src/sgx/test/upgrade/test_upgrade.c
@@ -84,15 +84,20 @@ const uint8_t mock_format_settings[] = {
 
 #define EVIDENCE_MAGIC 0xD4
 #define EVIDENCE_PRELUDE "mock_evidence:"
+#define EVIDENCE_AT_TYPE uint64_t
+#define EVIDENCE_AT_SIZE (sizeof(EVIDENCE_AT_TYPE))
 #define EVIDENCE_HEADER                                                \
     EVIDENCE_PRELUDE                                                   \
     "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" \
     "TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT"
-#define EVIDENCE_OH_SIZE 200
-#define EVIDENCE_SIZE (strlen(EVIDENCE_HEADER) + EVIDENCE_OH_SIZE)
+#define EVIDENCE_HEADER_SIZE (strlen(EVIDENCE_HEADER) + EVIDENCE_AT_SIZE)
+#define EVIDENCE_OH_SIZE (200)
+#define EVIDENCE_SIZE (EVIDENCE_HEADER_SIZE + EVIDENCE_OH_SIZE)
 #define EVIDENCE_FR_OFFSET (strlen(EVIDENCE_PRELUDE))
 #define EVIDENCE_TO_OFFSET (strlen(EVIDENCE_PRELUDE) + mre_size)
-#define EVIDENCE_PK_OFFSET (strlen(EVIDENCE_PRELUDE) + mre_size * 2)
+#define EVIDENCE_AT_OFFSET (strlen(EVIDENCE_PRELUDE) + mre_size * 2)
+#define EVIDENCE_PK_OFFSET \
+    (strlen(EVIDENCE_PRELUDE) + mre_size * 2 + EVIDENCE_AT_SIZE)
 
 const oe_claim_t source_mrenclave_claim = {
     .name = OE_CLAIM_UNIQUE_ID,
@@ -138,6 +143,7 @@ struct {
     bool evidence_get_format_settings;
     bool evidence_generate;
     bool evidence_verify_and_extract_claims;
+    bool evidence_debug_mode;
     char local_enclave_id;
     bool evidence_get_claim;
     bool random_getrandom;
@@ -228,7 +234,12 @@ bool evidence_generate(evidence_format_t* format,
     *evidence_buffer = malloc(*evidence_buffer_size);
     memset(*evidence_buffer, EVIDENCE_MAGIC, *evidence_buffer_size);
     memcpy(*evidence_buffer, EVIDENCE_PRELUDE, strlen(EVIDENCE_PRELUDE));
+    memset(*evidence_buffer + EVIDENCE_AT_OFFSET, 0, EVIDENCE_AT_SIZE);
     memcpy(*evidence_buffer + EVIDENCE_PK_OFFSET, ccs, ccs_size);
+    if (G_mocks.evidence_debug_mode) {
+        *((EVIDENCE_AT_TYPE*)(*evidence_buffer + EVIDENCE_AT_OFFSET)) |=
+            OE_EVIDENCE_ATTRIBUTES_SGX_DEBUG;
+    }
     switch (G_mocks.local_enclave_id) {
     case 's':
         memcpy(*evidence_buffer + EVIDENCE_FR_OFFSET, src_mre, mre_size);
@@ -284,15 +295,18 @@ bool evidence_verify_and_extract_claims(oe_uuid_t format_id,
          i++)
         has_pk |= evidence_buffer[i] != EVIDENCE_MAGIC;
 
-    *claims_size = has_pk ? 2 : 1;
+    *claims_size = has_pk ? 3 : 2;
     *claims = malloc(sizeof(oe_claim_t) * (*claims_size));
     (*claims)[0].name = OE_CLAIM_UNIQUE_ID;
     (*claims)[0].value = evidence_buffer + EVIDENCE_FR_OFFSET;
     (*claims)[0].value_size = mre_size;
+    (*claims)[1].name = OE_CLAIM_ATTRIBUTES;
+    (*claims)[1].value = evidence_buffer + EVIDENCE_AT_OFFSET;
+    (*claims)[1].value_size = EVIDENCE_AT_SIZE;
     if (has_pk) {
-        (*claims)[1].name = OE_CLAIM_CUSTOM_CLAIMS_BUFFER;
-        (*claims)[1].value = evidence_buffer + EVIDENCE_PK_OFFSET;
-        (*claims)[1].value_size = CLAIM_PK_SIZE;
+        (*claims)[2].name = OE_CLAIM_CUSTOM_CLAIMS_BUFFER;
+        (*claims)[2].value = evidence_buffer + EVIDENCE_PK_OFFSET;
+        (*claims)[2].value_size = CLAIM_PK_SIZE;
     }
 
     return true;
@@ -315,14 +329,17 @@ oe_claim_t* evidence_get_claim(oe_claim_t* claims,
     if (!G_mocks.evidence_get_claim)
         return NULL;
 
-    assert(claims_size == 1 || claims_size == 2);
+    assert(claims_size == 2 || claims_size == 3);
     assert(!strcmp(OE_CLAIM_UNIQUE_ID, claim_name) ||
-           !strcmp(OE_CLAIM_CUSTOM_CLAIMS_BUFFER, claim_name));
+           !strcmp(OE_CLAIM_CUSTOM_CLAIMS_BUFFER, claim_name) ||
+           !strcmp(OE_CLAIM_ATTRIBUTES, claim_name));
 
     if (!strcmp(OE_CLAIM_UNIQUE_ID, claim_name))
         return &claims[0];
-    if (claims_size == 2 && !strcmp(OE_CLAIM_CUSTOM_CLAIMS_BUFFER, claim_name))
+    if (!strcmp(OE_CLAIM_ATTRIBUTES, claim_name))
         return &claims[1];
+    if (claims_size == 3 && !strcmp(OE_CLAIM_CUSTOM_CLAIMS_BUFFER, claim_name))
+        return &claims[2];
 
     return NULL;
 }
@@ -371,6 +388,7 @@ void setup(char local_enclave_id) {
     G_mocks.evidence_generate = true;
     G_mocks.evidence_verify_and_extract_claims = true;
     G_mocks.evidence_get_claim = true;
+    G_mocks.evidence_debug_mode = false;
     G_mocks.random_getrandom = true;
 }
 
@@ -398,7 +416,7 @@ void identify_self() {
 
     assert(EVIDENCE_SIZE == total);
     assert(!memcmp(EVIDENCE_PRELUDE, buf, strlen(EVIDENCE_PRELUDE)));
-    for (size_t i = strlen(EVIDENCE_HEADER); i < EVIDENCE_SIZE; i++)
+    for (size_t i = EVIDENCE_HEADER_SIZE; i < EVIDENCE_SIZE; i++)
         assert(EVIDENCE_MAGIC == buf[i]);
     switch (G_mocks.local_enclave_id) {
     case 's':
@@ -416,6 +434,9 @@ void identify_self() {
     }
     assert(!memcmp(expected_fr, buf + EVIDENCE_FR_OFFSET, mre_size));
     assert(!memcmp(expected_to, buf + EVIDENCE_TO_OFFSET, mre_size));
+    assert(G_mocks.evidence_debug_mode ==
+           (*((EVIDENCE_AT_TYPE*)(buf + EVIDENCE_AT_OFFSET)) &
+            OE_EVIDENCE_ATTRIBUTES_SGX_DEBUG));
     assert(!memcmp(expected_pk, buf + EVIDENCE_PK_OFFSET, CLAIM_PK_SIZE));
 }
 
@@ -432,6 +453,7 @@ void identify_peer(bool correct, bool pubkey) {
     peer_evidence = malloc(EVIDENCE_SIZE);
     memset(peer_evidence, EVIDENCE_MAGIC, EVIDENCE_SIZE);
     memcpy(peer_evidence, EVIDENCE_PRELUDE, strlen(EVIDENCE_PRELUDE));
+    EVIDENCE_AT_TYPE peer_attributes = 0;
     if (correct) {
         switch (G_mocks.local_enclave_id) {
         case 's':
@@ -445,8 +467,13 @@ void identify_peer(bool correct, bool pubkey) {
             pk = (uint8_t*)mock_pub_key_src;
             break;
         }
+        if (G_mocks.evidence_debug_mode)
+            peer_attributes |= OE_EVIDENCE_ATTRIBUTES_SGX_DEBUG;
         memcpy(peer_evidence + EVIDENCE_FR_OFFSET, mre_fr, mre_size);
         memcpy(peer_evidence + EVIDENCE_TO_OFFSET, mre_to, mre_size);
+        memcpy(peer_evidence + EVIDENCE_AT_OFFSET,
+               &peer_attributes,
+               sizeof(peer_attributes));
         if (pubkey)
             memcpy(peer_evidence + EVIDENCE_PK_OFFSET, pk, CLAIM_PK_SIZE);
     }
@@ -865,6 +892,31 @@ void test_upgrade_export_invalid_peer_id() {
         0x6A03);
 }
 
+void test_upgrade_export_peer_in_debug_mode() {
+    unsigned int rx;
+
+    setup('s');
+    G_mocks.evidence_debug_mode = true;
+    printf("Test exporting when peer is in debug mode...\n");
+
+    ASSERT_THROWS(
+        {
+            // Start export
+            SET_APDU("\x80\xA6\x01\x01" SRC_MRE DST_MRE, rx);
+            assert(3 == upgrade_process_apdu(rx));
+            // Spec auth
+            SET_APDU("\x80\xA6\x02" SIG_VALID_1, rx);
+            assert(3 == upgrade_process_apdu(rx));
+            ASSERT_APDU("\x80\xA6\x01");
+            SET_APDU("\x80\xA6\x02" SIG_VALID_2, rx);
+            assert(3 == upgrade_process_apdu(rx));
+            ASSERT_APDU("\x80\xA6\x00");
+            identify_self();
+            identify_peer(true, true);
+        },
+        0x6A03);
+}
+
 void test_upgrade_export_peer_id_nopubkey() {
     unsigned int rx;
 
@@ -1081,6 +1133,31 @@ void test_upgrade_import_invalid_peer_id() {
         0x6A03);
 }
 
+void test_upgrade_import_peer_in_debug_mode() {
+    unsigned int rx;
+
+    setup('d');
+    G_mocks.evidence_debug_mode = true;
+    printf("Test importing when peer is in debug mode...\n");
+
+    ASSERT_THROWS(
+        {
+            // Start import
+            SET_APDU("\x80\xA6\x01\x02" SRC_MRE DST_MRE, rx);
+            assert(3 == upgrade_process_apdu(rx));
+            // Spec auth
+            SET_APDU("\x80\xA6\x02" SIG_VALID_1, rx);
+            assert(3 == upgrade_process_apdu(rx));
+            ASSERT_APDU("\x80\xA6\x01");
+            SET_APDU("\x80\xA6\x02" SIG_VALID_2, rx);
+            assert(3 == upgrade_process_apdu(rx));
+            ASSERT_APDU("\x80\xA6\x00");
+            identify_self();
+            identify_peer(true, true);
+        },
+        0x6A03);
+}
+
 void test_upgrade_import_migrate_fails() {
     unsigned int rx;
 
@@ -1160,6 +1237,7 @@ int main() {
     test_upgrade_export_invalid_spec_auth_format();
     test_upgrade_export_cant_get_randomness();
     test_upgrade_export_invalid_peer_id();
+    test_upgrade_export_peer_in_debug_mode();
     test_upgrade_export_peer_id_nopubkey();
     test_upgrade_export_peer_id_empty_packet();
     test_upgrade_export_peer_id_packet_too_big();
@@ -1175,6 +1253,7 @@ int main() {
     test_upgrade_import_cant_verify_local_evidence();
     test_upgrade_import_cant_find_local_mrenclave();
     test_upgrade_import_invalid_peer_id();
+    test_upgrade_import_peer_in_debug_mode();
     test_upgrade_import_migrate_fails();
 
     test_upgrade_invalid_op();

--- a/middleware/admin/verify_sgx_attestation.py
+++ b/middleware/admin/verify_sgx_attestation.py
@@ -29,6 +29,7 @@ from .sgx_utils import get_sgx_extensions, get_tcb_info, validate_tcb_info, \
                        get_qeid_info, validate_qeid_info
 from .x509_validator import X509CertificateValidator
 from .certificate import HSMCertificate, HSMCertificateV2ElementX509
+from sgx.envelope import SgxAttributesFlags
 
 
 # ###################################################################################
@@ -177,12 +178,26 @@ def do_verify_attestation(options):
             f" but attestation reports {reported_pubkeys_hash.hex()}"
         )
 
+    signer_warnings = []
+
+    if SgxAttributesFlags.DEBUG.is_set(sgx_quote.report_body.attributes.flags):
+        signer_warnings.append("SGX enclave running in DEBUG MODE")
+
+    signer_warnings_output = []
+    if len(signer_warnings) > 0:
+        signer_warnings_output.append("************* WARNINGS *************")
+        signer_warnings_output += map(lambda w: f"> {w}", signer_warnings)
+        signer_warnings_output.append("************************************")
+
+    quote_attributes = sgx_quote.report_body.attributes
     signer_info = [
         f"Hash: {pubkeys_hash.hex()}",
         "",
         f"Installed powHSM MRENCLAVE: {sgx_quote.report_body.mrenclave.hex()}",
         f"Installed powHSM MRSIGNER: {sgx_quote.report_body.mrsigner.hex()}",
         f"Installed powHSM version: {powhsm_message.version}",
+        f"Installed powHSM ATTRIBUTES (flgs): {quote_attributes.flags:016x}",
+        f"Installed powHSM ATTRIBUTES (xfrm): {quote_attributes.xfrm:016x}",
     ]
 
     signer_info += [
@@ -224,7 +239,10 @@ def do_verify_attestation(options):
     ]
 
     head(
-        ["powHSM verified with public keys:"] + pubkeys_output + signer_info,
+        signer_warnings_output +
+        ["powHSM verified with public keys:"] +
+        pubkeys_output +
+        signer_info,
         fill="-",
     )
 

--- a/middleware/comm/utils.py
+++ b/middleware/comm/utils.py
@@ -22,6 +22,12 @@
 
 import re
 from Crypto.Hash import keccak
+from enum import IntEnum
+
+
+class BitFlags(IntEnum):
+    def is_set(self, value: int) -> bool:
+        return (value & int(self)) == int(self)
 
 
 def bitwise_and_bytes(bs1, bs2):

--- a/middleware/sgx/envelope.py
+++ b/middleware/sgx/envelope.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 from comm.cstruct import CStruct
+from comm.utils import BitFlags
 
 
 class SgxEnvelope(CStruct):
@@ -51,6 +52,18 @@ class SgxEnvelope(CStruct):
 ##############################################################################
 # Types below taken from OpenEnclave's include/openenclave/bits/sgx/sgxtypes.h
 ##############################################################################
+
+
+class SgxAttributesFlags(BitFlags):
+    """
+    sgx_attributes_t flags bits
+    """
+    INITTED = 0x0000000000000001
+    DEBUG = 0x0000000000000002
+    MODE64BIT = 0x0000000000000004
+    PROVISION_KEY = 0x0000000000000010
+    EINITTOKEN_KEY = 0x0000000000000020
+    KSS = 0x0000000000000040
 
 
 class SgxAttributes(CStruct):

--- a/middleware/tests/admin/test_verify_sgx_attestation.py
+++ b/middleware/tests/admin/test_verify_sgx_attestation.py
@@ -27,6 +27,7 @@ from parameterized import parameterized
 from admin.misc import AdminError
 from admin.pubkeys import PATHS
 from admin.verify_sgx_attestation import do_verify_attestation, DEFAULT_ROOT_AUTHORITY
+from sgx.envelope import SgxAttributesFlags
 import ecdsa
 import secp256k1 as ec
 import hashlib
@@ -86,6 +87,10 @@ class TestVerifySgxAttestation(TestCase):
             "report_body": SimpleNamespace(**{
                 "mrenclave": bytes.fromhex("aabbccdd"),
                 "mrsigner": bytes.fromhex("1122334455"),
+                "attributes": SimpleNamespace(**{
+                    "flags": 0x0000112233445565,
+                    "xfrm": 0x000000778899aabb,
+                })
             })
         })
 
@@ -157,16 +162,25 @@ class TestVerifySgxAttestation(TestCase):
         }
 
     @parameterized.expand([
-        ("default_root", None),
-        ("custom_root", "a-custom-root")
+        ("default_root", None, None),
+        ("custom_root", "a-custom-root", None),
+        ("debug_mode", None, 0x1122334455667702),
     ])
     def test_verify_attestation(self, get_sgx_root_of_trust, load_pubkeys,
                                 HSMCertificate, get_tcb_info, validate_tcb_info,
                                 get_qeid_info, validate_qeid_info,
-                                head, _, __, custom_root):
+                                head, _, __, custom_root, attr_flags):
         self.configure_mocks(get_sgx_root_of_trust, load_pubkeys, HSMCertificate,
                              get_tcb_info, validate_tcb_info,
                              get_qeid_info, validate_qeid_info, head)
+
+        if attr_flags:
+            self.mock_sgx_quote.report_body.attributes = SimpleNamespace(**{
+                "flags": attr_flags,
+                "xfrm": 0x000000778899aabb,
+            })
+        expected_attr_flags = self.mock_sgx_quote.report_body.attributes.flags
+
         if custom_root:
             self.options.root_authority = custom_root
 
@@ -213,7 +227,15 @@ class TestVerifySgxAttestation(TestCase):
         self.validate_qeid_info.assert_called_with(
             self.mock_qe_collateral, "the enclave identity")
 
-        self.assertEqual(head.call_args_list[1], call([
+        expected_signer_warnings = []
+        if SgxAttributesFlags.DEBUG.is_set(expected_attr_flags):
+            expected_signer_warnings = [
+                "************* WARNINGS *************",
+                "> SGX enclave running in DEBUG MODE",
+                "************************************",
+            ]
+
+        self.assertEqual(head.call_args_list[1], call(expected_signer_warnings + [
             "powHSM verified with public keys:"
         ] + self.expected_pubkeys_output + [
             f"Hash: {self.expected_pubkeys_hash}",
@@ -221,6 +243,8 @@ class TestVerifySgxAttestation(TestCase):
             "Installed powHSM MRENCLAVE: aabbccdd",
             "Installed powHSM MRSIGNER: 1122334455",
             "Installed powHSM version: 5.6",
+            f"Installed powHSM ATTRIBUTES (flgs): {expected_attr_flags:016x}",
+            "Installed powHSM ATTRIBUTES (xfrm): 000000778899aabb",
             "Platform: plf",
             f"UD value: {'aa'*32}",
             f"Best block: {'bb'*32}",

--- a/middleware/tests/comm/test_utils.py
+++ b/middleware/tests/comm/test_utils.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 from unittest import TestCase
-from comm.utils import bitwise_and_bytes, keccak_256
+from comm.utils import BitFlags, bitwise_and_bytes, keccak_256
 from parameterized import parameterized
 
 import logging
@@ -56,6 +56,55 @@ class TestBitwiseAndBytes(TestCase):
             bitwise_and_bytes(bytes.fromhex("123456779a"),
                               bytes.fromhex("0406080e0d")).hex(),
         )
+
+
+class _TestFlags(BitFlags):
+    NONE = 0x00
+    READ = 0x01
+    WRITE = 0x02
+    EXECUTE = 0x04
+    ADMIN = 0x08
+    READ_WRITE = READ | WRITE
+    ALL = READ | WRITE | EXECUTE | ADMIN
+
+
+class TestBitFlagsIsSet(TestCase):
+    @parameterized.expand([
+        (_TestFlags.READ, 0x01),
+        (_TestFlags.WRITE, 0x02),
+        (_TestFlags.EXECUTE, 0x04),
+        (_TestFlags.ADMIN, 0x08),
+        (_TestFlags.READ_WRITE, 0x03),
+        (_TestFlags.ALL, 0x0F),
+    ])
+    def test_is_set_exact_matches(self, flag, value):
+        self.assertTrue(flag.is_set(value))
+
+    @parameterized.expand([
+        (_TestFlags.READ, 0x0F),
+        (_TestFlags.WRITE, 0x0F),
+        (_TestFlags.EXECUTE, 0x0F),
+        (_TestFlags.ADMIN, 0x0F),
+        (_TestFlags.READ_WRITE, 0x0F),
+    ])
+    def test_is_set_with_additional_bits(self, flag, value):
+        self.assertTrue(flag.is_set(value))
+
+    @parameterized.expand([
+        (_TestFlags.READ, 0x00),
+        (_TestFlags.WRITE, 0x01),
+        (_TestFlags.EXECUTE, 0x03),
+        (_TestFlags.ADMIN, 0x07),
+        (_TestFlags.READ_WRITE, 0x01),
+        (_TestFlags.READ_WRITE, 0x02),
+        (_TestFlags.ALL, 0x07),
+    ])
+    def test_is_set_false_when_any_required_bit_missing(self, flag, value):
+        self.assertFalse(flag.is_set(value))
+
+    def test_zero_flag_is_always_set(self):
+        self.assertTrue(_TestFlags.NONE.is_set(0x00))
+        self.assertTrue(_TestFlags.NONE.is_set(0x0F))
 
 
 class TestKeccak256(TestCase):

--- a/middleware/tests/sgx/test_envelope.py
+++ b/middleware/tests/sgx/test_envelope.py
@@ -23,6 +23,7 @@
 from unittest import TestCase
 from parameterized import parameterized
 from sgx.envelope import SgxAttributes, \
+                         SgxAttributesFlags, \
                          SgxReportData, \
                          SgxReportBody, \
                          SgxEcdsa256Signature, \
@@ -110,3 +111,49 @@ class TestSgxStructs(TestCase):
     ])
     def test_sizes_ok(self, _, kls, exp_len):
         self.assertEqual(exp_len, kls.get_bytelength())
+
+
+class TestSgxAttributesFlags(TestCase):
+    @parameterized.expand([
+        ("initted_exact", SgxAttributesFlags.INITTED, int(SgxAttributesFlags.INITTED)),
+        ("debug_exact", SgxAttributesFlags.DEBUG, int(SgxAttributesFlags.DEBUG)),
+        ("mode64_exact", SgxAttributesFlags.MODE64BIT, int(SgxAttributesFlags.MODE64BIT)),
+        ("provision_exact", SgxAttributesFlags.PROVISION_KEY,
+         int(SgxAttributesFlags.PROVISION_KEY)),
+        ("einittoken_exact", SgxAttributesFlags.EINITTOKEN_KEY,
+         int(SgxAttributesFlags.EINITTOKEN_KEY)),
+        ("kss_exact", SgxAttributesFlags.KSS, int(SgxAttributesFlags.KSS)),
+    ])
+    def test_is_set_exact(self, _, flag, value):
+        self.assertTrue(flag.is_set(value))
+
+    @parameterized.expand([
+        ("initted", SgxAttributesFlags.INITTED),
+        ("debug", SgxAttributesFlags.DEBUG),
+        ("mode64", SgxAttributesFlags.MODE64BIT),
+        ("provision", SgxAttributesFlags.PROVISION_KEY),
+        ("einittoken", SgxAttributesFlags.EINITTOKEN_KEY),
+        ("kss", SgxAttributesFlags.KSS),
+    ])
+    def test_is_set_with_additional_bits(self, _, flag):
+        combined = int(SgxAttributesFlags.INITTED) | \
+                   int(SgxAttributesFlags.DEBUG) | \
+                   int(SgxAttributesFlags.KSS)
+        if flag in (SgxAttributesFlags.MODE64BIT,
+                    SgxAttributesFlags.PROVISION_KEY,
+                    SgxAttributesFlags.EINITTOKEN_KEY):
+            self.assertFalse(flag.is_set(combined))
+        else:
+            self.assertTrue(flag.is_set(combined))
+
+    @parameterized.expand([
+        ("initted", SgxAttributesFlags.INITTED, 0),
+        ("debug", SgxAttributesFlags.DEBUG, int(SgxAttributesFlags.INITTED)),
+        ("mode64", SgxAttributesFlags.MODE64BIT, int(SgxAttributesFlags.DEBUG)),
+        ("provision", SgxAttributesFlags.PROVISION_KEY, int(SgxAttributesFlags.KSS)),
+        ("einittoken", SgxAttributesFlags.EINITTOKEN_KEY,
+         int(SgxAttributesFlags.MODE64BIT)),
+        ("kss", SgxAttributesFlags.KSS, int(SgxAttributesFlags.PROVISION_KEY)),
+    ])
+    def test_not_set_when_missing(self, _, flag, value):
+        self.assertFalse(flag.is_set(value))


### PR DESCRIPTION
- Emitting a visible warning on SGX attestation verification if the enclave was running in debug mode
- Preventing SGX DB exporting/importing to/from an enclave that is in debug mode
- Actually running the enclave in debug mode for debug builds
- Adding MRSIGNER information on SGX builds and distribution builds
- Added and updated unit tests